### PR TITLE
feat: meet the liquid glass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "682934e0b3edd935f938f7f958beab52c32b4fffe67f4b9dd7a2b59a22b7e2b4"
+checksum = "20fbab13e2db8d9a2a650396f8e11101794c729f90dab2163b5e504309aa4c0c"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-apple"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af0e18756d06e6f9112186e8d375465def2675acc190a0e5176baaf3e0dd5b07"
+checksum = "43c09a6ea26c06e2f261d57615ea248ba2cb697447df8d29c81c396393415967"
 dependencies = [
  "anyhow",
  "bezel-gpui",
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-linux"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcfe9355e4580721e6fd0614ed71fc27b8479ad0f3e4d1d2a73003a3ac22ca4"
+checksum = "3613198c68b2ab9044e9e2fe07fcb58c6388ed6efe292f4857dd14c3c699be1e"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-macos"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893230bb1bc4d52aa624577655c38452e09022b6bcc423965a20610894d2a9bb"
+checksum = "3999aae1fb01b205d9d75d2b3610a418e51f89d99673a975c8bbb0bb904eff10"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-macros"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8678cb892b6616281213ef53443c16c41face5110f7a56c0e8f0c0ce3f9ce7"
+checksum = "82dc1e0ada1e4bc52f220812ad7fedd49602465d92e7b5bbcef722c077548a22"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-platform"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154ee1e01f7d8ee81e4515128be415927503ff9249b9db72e33a22de3940f602"
+checksum = "bad0d53cb228a0f199a4401863967bf2bbf89e0005e5dfddc8becfa915da686f"
 dependencies = [
  "bezel-gpui",
  "bezel-gpui-linux",
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-shared-string"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecf1afc6b64ffb21c227a2b20136bb711a91cf5f5fbc59750378eac4809d1b9"
+checksum = "8470ee2fea8a0cf2ad214f10eb4d27286d87a4b522f5404a29221525e6a4b84f"
 dependencies = [
  "schemars",
  "serde",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-util"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3802bf713bd7454bad4e61df660699fa31e25fa9b1334447074742c87e881dcf"
+checksum = "8400d3f208467e1c0a361625400293c823fb0298d6c5d067bf44772783cb2b95"
 dependencies = [
  "anyhow",
  "log",
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-web"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65dbce4a8980e957df785bb1b153772ca290f3f4e2c8e6009117c8fa75ed3009"
+checksum = "8c9628f49fef214b7cf3ee89f887d7c0539a08ab2d93bf39eb1e96f51c0baf10"
 dependencies = [
  "anyhow",
  "bezel-gpui",
@@ -858,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-wgpu"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87abc0f28bd17c12bf404d1cae9269123613d078893a812be67efe9bd31924ba"
+checksum = "84549f8583c6dcd38a05c916fbe3a96c66a591256ef6c0f19511d0d52f815e1a"
 dependencies = [
  "anyhow",
  "bezel-gpui",
@@ -884,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-windows"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c9de60253f4c536c250873b837dc7615050cc9f6e36389cc09241a8be0f184"
+checksum = "10482118f54809f11a5efb56010d6399128df467ae7b62bab538e5a44bee78e2"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -980,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-collections"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000ce01f5d7d41db426f25ad62c34692939fe95def66434ffa205b5f390b8c42"
+checksum = "43e95068c29c7006b9c4d8a06d232496c24c7203403220994726b7a43e4758d8"
 dependencies = [
  "bezel-gpui-util",
  "indexmap",
@@ -991,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-derive-refineable"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954c11688abcdaa225dc903bc971eae55f8601807a6d29f5ff9618d302217f55"
+checksum = "0bb6889ebc88fbe7323f24f28c57c886b1df93b9a6c10d3cdfa1da532a4bfbe2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1002,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-http-client"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd0f5dac3658bf7972dec06e09d32ba1e657f69260650822f105d9aab2e1527"
+checksum = "29738acc16a2f33b6af4a718eb83a17b023f740b11250d7ed3a7fbf59dd21907"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1023,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-http-client-tls"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8aa61937e57057aba27a8c7c9ca774930de0161a190663a7bde0c89eaa86a5"
+checksum = "cb52791bf0c7ff6ac11f6ca564b2b707ae2bdc4e9402f7db78287989dc7b3064"
 dependencies = [
  "rustls",
  "rustls-platform-verifier",
@@ -1033,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-media"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2610e90725223186a4a19e2893861eba0ecb4c4e89ec58ea81a5af65120397d"
+checksum = "24905261e1de5ac4b1f5eded33364ca5ad18e17e8c78720a2fbdcda8b449886b"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -1048,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-perf"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "506a63f98422a33a7c9515c5a97cd4aa7556194b655146e9dd0b4a8a09824d4d"
+checksum = "c1cc77652bd0536cb1aa06b24a0e3d757d211e8c3d9225e47a402c1f6e428e6a"
 dependencies = [
  "bezel-zed-collections",
  "serde",
@@ -1059,18 +1059,18 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-refineable"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9865ba1e536994a45a0c3ccab8458acbf1f0c03ea83abd8810fd19eb0f14b5"
+checksum = "ab7052ea948d09e5803733dd444370803b2c3186c4de830466314ecc80a98a3a"
 dependencies = [
  "bezel-zed-derive-refineable",
 ]
 
 [[package]]
 name = "bezel-zed-reqwest-client"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968f1271eead630574cdf5f743af09d0c7d4ba12e9efd1eca86296ba5a109f00"
+checksum = "183e58543e45caa2f95815ef1e5e1ac7b7366bb9b77b00e729f535407d8a886d"
 dependencies = [
  "anyhow",
  "bezel-gpui-util",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-scheduler"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4078e7552bafe0ff0ac818e8efa8ffbc27308a8d3311c8db805356ed781e1e"
+checksum = "33e337a7eaa37447707532b02d8246ce87050e8ad3755e022b6e0046a1c6e1c8"
 dependencies = [
  "async-task",
  "backtrace",
@@ -1102,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-sum-tree"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36501eef60dcb85940b22dc0fe01f520dfe831aecd682cec4f0e253138e7f3a"
+checksum = "c20d8a5ce24a2348ccb8dcac911d5ceef3094216af6d1ffcc2bdfced8316a263"
 dependencies = [
  "bezel-zed-ztracing",
  "heapless",
@@ -1115,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-util-macros"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c781e86b7910daaf81a04d19cb00358d1a880f2a669f325c687acec40f8cbdf"
+checksum = "f5f59daae2145fae0a9604f8358bed8bed4686fc88ed52e466cfcff7597ca68b"
 dependencies = [
  "bezel-zed-perf",
  "quote",
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-zlog"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df220d9c1d37b83a325ce8df3c8970982710e59be132ec3dca833d8bfdd996cc"
+checksum = "2a4feb9e185efc8e8cbe95ced50dbb47cec2f2d6a4a2e293f081bbd5aa7e013d"
 dependencies = [
  "anyhow",
  "bezel-zed-collections",
@@ -1138,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-ztracing"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d9373318536a91924497ff5cb6cf65b1c917662126b9899a42354aea1078d4"
+checksum = "61b1b7202c4676b48baab5c74d46db5fb46bc1fcf291e9aad44e7592671179c1"
 dependencies = [
  "bezel-zed-zlog",
  "bezel-zed-ztracing-macro",
@@ -1150,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-ztracing-macro"
-version = "0.3.4+zed.d9ad6a"
+version = "0.3.5+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3d1d24fb398cdb35dd09ee495b04154cb0c9cdedc09a8b4a52ba23d20e2f70"
+checksum = "2cc10fe879fc0a4c612267e6f4f3d30fee73f2bb85ba2ee0a0083d2232a7a4b5"
 
 [[package]]
 name = "bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bezel"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bezel-agent",
  "bezel-gpui",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-agent"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-editor"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bezel-gpui",
  "bezel-markdown",
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20fbab13e2db8d9a2a650396f8e11101794c729f90dab2163b5e504309aa4c0c"
+checksum = "84ad47bc509a9b37c318dcc7b0d5cb21866367b07ffca4e67e1921f73681c68d"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-apple"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c09a6ea26c06e2f261d57615ea248ba2cb697447df8d29c81c396393415967"
+checksum = "445ddc07caf45ca252689a9e70edcf6fccdf356b303c69b071d0e8588dd61cd9"
 dependencies = [
  "anyhow",
  "bezel-gpui",
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-linux"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3613198c68b2ab9044e9e2fe07fcb58c6388ed6efe292f4857dd14c3c699be1e"
+checksum = "1afdbd07e9f25fd9066df608ec760b9647a4cd576b87e1ca1a0cdbca55572ccb"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-macos"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3999aae1fb01b205d9d75d2b3610a418e51f89d99673a975c8bbb0bb904eff10"
+checksum = "3ca101161b2e487383e4b20f91591bae408d2e519e7fb7202d9575bd296f5e6c"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-macros"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82dc1e0ada1e4bc52f220812ad7fedd49602465d92e7b5bbcef722c077548a22"
+checksum = "30972f35b3af7dbda03a3002b2d43dbb903c2fe7a1bf7afea0bf39aff2fe3a92"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-platform"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad0d53cb228a0f199a4401863967bf2bbf89e0005e5dfddc8becfa915da686f"
+checksum = "62a332b4d90b6f4a0dcfab6f8850c85466eb0b7923e77b0544260294f89de914"
 dependencies = [
  "bezel-gpui",
  "bezel-gpui-linux",
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-shared-string"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8470ee2fea8a0cf2ad214f10eb4d27286d87a4b522f5404a29221525e6a4b84f"
+checksum = "0a0b6de5b471072d76448f99ab05112cc0137fa39859d72987f680dee68349f7"
 dependencies = [
  "schemars",
  "serde",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-util"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8400d3f208467e1c0a361625400293c823fb0298d6c5d067bf44772783cb2b95"
+checksum = "c1a2aed7a278fb5b380b51faddb468f80881636909a8509613a7501affdbead8"
 dependencies = [
  "anyhow",
  "log",
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-web"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9628f49fef214b7cf3ee89f887d7c0539a08ab2d93bf39eb1e96f51c0baf10"
+checksum = "c9bec75c72100018d2ae7037fae4fd4738199b8cf71a65b1c3933e2e4ac77052"
 dependencies = [
  "anyhow",
  "bezel-gpui",
@@ -858,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-wgpu"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84549f8583c6dcd38a05c916fbe3a96c66a591256ef6c0f19511d0d52f815e1a"
+checksum = "62bb19c01138a28ba8b9b55a2007e3fb20f4bee59cee9717e1fa439ca907f8c1"
 dependencies = [
  "anyhow",
  "bezel-gpui",
@@ -884,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-windows"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10482118f54809f11a5efb56010d6399128df467ae7b62bab538e5a44bee78e2"
+checksum = "e8e1fb3e9c93d377ff6f089432de53fc7d6dcc0098435e93a231083da4e56b9c"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-markdown"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-motion"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-syntax"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bezel-theme",
  "tree-sitter",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-terminal"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alacritty_terminal",
  "bezel-gpui",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-theme"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bezel-gpui",
  "objc",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-ui"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bezel-gpui",
  "bezel-motion",
@@ -980,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-collections"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e95068c29c7006b9c4d8a06d232496c24c7203403220994726b7a43e4758d8"
+checksum = "90279507271cf5f5fa2e4d7f988c36e90b5a8aa654573a74146b91da0ab71044"
 dependencies = [
  "bezel-gpui-util",
  "indexmap",
@@ -991,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-derive-refineable"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb6889ebc88fbe7323f24f28c57c886b1df93b9a6c10d3cdfa1da532a4bfbe2"
+checksum = "c174b5575d7419fb4a86f49624878d7794992ab5efe8f0eb9fe3ac266aa40b5b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1002,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-http-client"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29738acc16a2f33b6af4a718eb83a17b023f740b11250d7ed3a7fbf59dd21907"
+checksum = "5604bd1ab49555fdfaf3d8b68fc9795d0cecd8d005c5a8d2f3f87450471ef9dc"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1023,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-http-client-tls"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb52791bf0c7ff6ac11f6ca564b2b707ae2bdc4e9402f7db78287989dc7b3064"
+checksum = "25bdc71d63295b9412a1e0f366a90b8e1da766cacbbe8149d6675c69f68f9a60"
 dependencies = [
  "rustls",
  "rustls-platform-verifier",
@@ -1033,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-media"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24905261e1de5ac4b1f5eded33364ca5ad18e17e8c78720a2fbdcda8b449886b"
+checksum = "21e7405dcebb53884faf6348c1958b2ae27dda9efceed53759af91f0d2cb00b1"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -1048,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-perf"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc77652bd0536cb1aa06b24a0e3d757d211e8c3d9225e47a402c1f6e428e6a"
+checksum = "27ec5a03f32efbdf6e3499f2006a1d55104b20b25ec312332ec4c36dc5c29e23"
 dependencies = [
  "bezel-zed-collections",
  "serde",
@@ -1059,18 +1059,18 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-refineable"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7052ea948d09e5803733dd444370803b2c3186c4de830466314ecc80a98a3a"
+checksum = "b1c447cec97fed82b00f1b895cd33c250da9dc068fcbd840d5d1f7366b6a2791"
 dependencies = [
  "bezel-zed-derive-refineable",
 ]
 
 [[package]]
 name = "bezel-zed-reqwest-client"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183e58543e45caa2f95815ef1e5e1ac7b7366bb9b77b00e729f535407d8a886d"
+checksum = "514f40119b95b80d4ddba1e1be240697ab9c1f3bb4402d5e8323717e89b9b5cb"
 dependencies = [
  "anyhow",
  "bezel-gpui-util",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-scheduler"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e337a7eaa37447707532b02d8246ce87050e8ad3755e022b6e0046a1c6e1c8"
+checksum = "d49673b9444426ef51304b121cdd799561183b86108c19ec866ad9b294260a47"
 dependencies = [
  "async-task",
  "backtrace",
@@ -1102,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-sum-tree"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20d8a5ce24a2348ccb8dcac911d5ceef3094216af6d1ffcc2bdfced8316a263"
+checksum = "88761b1f941a8b88004c6247b15ed9a55c429d1631d5e95443b419af7a05d5c6"
 dependencies = [
  "bezel-zed-ztracing",
  "heapless",
@@ -1115,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-util-macros"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f59daae2145fae0a9604f8358bed8bed4686fc88ed52e466cfcff7597ca68b"
+checksum = "1ae9495ce1fd65f0816e1fe7d4168f4f486694514705e77bce1bf2d7b36a291e"
 dependencies = [
  "bezel-zed-perf",
  "quote",
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-zlog"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4feb9e185efc8e8cbe95ced50dbb47cec2f2d6a4a2e293f081bbd5aa7e013d"
+checksum = "af555b9c93a0921fd996dd1cd7ca01f54c58f2840209cd5622d7f387fb0ac9d2"
 dependencies = [
  "anyhow",
  "bezel-zed-collections",
@@ -1138,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-ztracing"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b1b7202c4676b48baab5c74d46db5fb46bc1fcf291e9aad44e7592671179c1"
+checksum = "ca321d7ddd04240a959cd8298ef8b3ef729ee4004daddb96ae688411f7921551"
 dependencies = [
  "bezel-zed-zlog",
  "bezel-zed-ztracing-macro",
@@ -1150,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-ztracing-macro"
-version = "0.3.5+zed.d9ad6a"
+version = "0.3.6+zed.d9ad6a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc10fe879fc0a4c612267e6f4f3d30fee73f2bb85ba2ee0a0083d2232a7a4b5"
+checksum = "17a923e7ae9f43df6e0482832c8549930e253b0e41c8b0d7ebcdbdb339f0e946"
 
 [[package]]
 name = "bindgen"
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "gallery"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bezel-agent",
  "bezel-editor",
@@ -2789,7 +2789,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bezel",
  "bezel-gpui",
@@ -6908,7 +6908,7 @@ dependencies = [
 
 [[package]]
 name = "web"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bezel-gpui",
  "bezel-gpui-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,11 +59,11 @@ serde_json = "1"
 tracing = "0.1"
 
 # Our zed fork, published from crabtalk/zed; the keys are what the source imports.
-gpui = { package = "bezel-gpui", version = "0.3.4" }
-gpui_platform = { package = "bezel-gpui-platform", version = "0.3.4", features = [
+gpui = { package = "bezel-gpui", version = "0.3.5" }
+gpui_platform = { package = "bezel-gpui-platform", version = "0.3.5", features = [
     "font-kit",
 ] }
-gpui_web = { package = "bezel-gpui-web", version = "0.3.4" }
+gpui_web = { package = "bezel-gpui-web", version = "0.3.5" }
 
 [workspace.lints.rust]
 # The objc 0.2 macros expand `cfg(feature = "cargo-clippy")` checks; declare

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "MIT"
 authors = ["clearloop <tianyi.gc@gmail.com>"]
@@ -30,15 +30,15 @@ rust-version = "1.85"
 [workspace.dependencies]
 # The short names are taken on crates.io, so packages publish as `bezel-*`; the
 # key here and each crate's `[lib] name` are what the source imports.
-bezel = { path = "crates/bezel", version = "0.1.2" }
-agent = { package = "bezel-agent", path = "crates/agent", version = "0.1.2" }
-theme = { package = "bezel-theme", path = "crates/theme", version = "0.1.2" }
-motion = { package = "bezel-motion", path = "crates/motion", version = "0.1.2" }
-ui = { package = "bezel-ui", path = "crates/ui", version = "0.1.2" }
-markdown = { package = "bezel-markdown", path = "crates/markdown", version = "0.1.2" }
-editor = { package = "bezel-editor", path = "crates/editor", version = "0.1.2" }
-syntax = { package = "bezel-syntax", path = "crates/syntax", version = "0.1.2" }
-terminal = { package = "bezel-terminal", path = "crates/terminal", version = "0.1.2" }
+bezel = { path = "crates/bezel", version = "0.1.3" }
+agent = { package = "bezel-agent", path = "crates/agent", version = "0.1.3" }
+theme = { package = "bezel-theme", path = "crates/theme", version = "0.1.3" }
+motion = { package = "bezel-motion", path = "crates/motion", version = "0.1.3" }
+ui = { package = "bezel-ui", path = "crates/ui", version = "0.1.3" }
+markdown = { package = "bezel-markdown", path = "crates/markdown", version = "0.1.3" }
+editor = { package = "bezel-editor", path = "crates/editor", version = "0.1.3" }
+syntax = { package = "bezel-syntax", path = "crates/syntax", version = "0.1.3" }
+terminal = { package = "bezel-terminal", path = "crates/terminal", version = "0.1.3" }
 
 # crates-io
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,11 +59,11 @@ serde_json = "1"
 tracing = "0.1"
 
 # Our zed fork, published from crabtalk/zed; the keys are what the source imports.
-gpui = { package = "bezel-gpui", version = "0.3.5" }
-gpui_platform = { package = "bezel-gpui-platform", version = "0.3.5", features = [
+gpui = { package = "bezel-gpui", version = "0.3.6" }
+gpui_platform = { package = "bezel-gpui-platform", version = "0.3.6", features = [
     "font-kit",
 ] }
-gpui_web = { package = "bezel-gpui-web", version = "0.3.5" }
+gpui_web = { package = "bezel-gpui-web", version = "0.3.6" }
 
 [workspace.lints.rust]
 # The objc 0.2 macros expand `cfg(feature = "cargo-clippy")` checks; declare

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A gpui component library, SwiftUI-lean: style flows through the environment,
 never through parameters.
 
-https://github.com/user-attachments/assets/6b5f16d0-9f58-48d6-8398-09acb1afa402
+https://github.com/user-attachments/assets/ba8a8946-edd9-4bc9-9fd2-a39fa249f495
 
 ```rust
 use bezel::ui::widgets::{ButtonStyle, Buttons};

--- a/apps/gallery/src/lib.rs
+++ b/apps/gallery/src/lib.rs
@@ -2877,11 +2877,7 @@ impl Gallery {
                                         .h(px(ph))
                                         .rounded(px(pr))
                                         .bg(theme.glass_overlay().opacity(self.probe_fill))
-                                        .material(if sigma > 0.0 {
-                                            sigma
-                                        } else {
-                                            ui::material::MENU_BLUR
-                                        })
+                                        .material(sigma)
                                         .into_any_element()
                                 },
                             )),
@@ -2907,6 +2903,12 @@ impl Gallery {
                                     .child(if self.probe_glass { "glass" } else { "frosted" })
                                     .on_click(cx.listener(|view, _, _, cx| {
                                         view.probe_glass = !view.probe_glass;
+                                        // Frost with no blur is a sharp pane, so arriving
+                                        // there lands on a readable one. Glass keeps 0,
+                                        // which is what clear means.
+                                        if !view.probe_glass && view.probe_blur == 0.0 {
+                                            view.probe_blur = 8.0 / 60.0;
+                                        }
                                         cx.notify();
                                     })),
                             )
@@ -2967,6 +2969,14 @@ impl Gallery {
                          at the rim. Both read very differently depending on the \
                          backdrop, which is what the switcher is for.",
                     ))
+                    .when(!ui::material::lensed(&theme), |el| {
+                        el.child(theme.warning_strip(
+                            "Liquid glass is macOS only — the lens is a Metal \
+                             primitive. Here it falls back to the backdrop tint: \
+                             the card and its shape, without the refraction at \
+                             the rim.",
+                        ))
+                    })
                     .child(probe)
                     .into_any_element()
             }

--- a/apps/gallery/src/lib.rs
+++ b/apps/gallery/src/lib.rs
@@ -8,7 +8,7 @@
 
 use gpui::{
     AnyElement, App, Axis, Context, DragMoveEvent, Empty, Entity, KeyBinding, SharedString, Window,
-    actions, div, prelude::*, px, relative,
+    actions, div, point, prelude::*, px, relative,
 };
 use motion::{AppExt as _, Fade, Painter};
 use rail::{Rail, Selected};
@@ -27,7 +27,7 @@ use ui::{
     icons,
     input::{self, Shape, TextField},
     list, loaders,
-    material::Frosted as _,
+    material::Glass as _,
     menubar::{self, Item, Menu, Menubar, MenubarEvent},
     pagination,
     palette::{self, CommandPalette, PaletteEvent},
@@ -811,6 +811,20 @@ pub struct Gallery {
     panel_demo: Floating,
     /// The Stats page's spinner — what the meter is there to catch.
     stats_spinner: bool,
+    /// The glass probe: where it has been dragged, its size and rounding as
+    /// slider fractions, and which backdrop it is over. Sizes are fractions
+    /// because that is what a slider reports.
+    probe_at: Floating,
+    probe_w: f32,
+    probe_h: f32,
+    probe_r: f32,
+    probe_bg: usize,
+    probe_glass: bool,
+    probe_bevel: f32,
+    probe_tint: bool,
+    probe_magnify: f32,
+    probe_blur: f32,
+    probe_fill: f32,
     /// Renders one section alone, without the nav, rail or header around it.
     /// The website embeds a page per component this way, so a doc page shows
     /// the component it documents rather than the whole browser.
@@ -951,6 +965,18 @@ impl Gallery {
             stats_at: Floating::new(Painter::of(cx)),
             panel_demo: Floating::new(Painter::of(cx)),
             stats_spinner: false,
+            probe_at: Floating::new(Painter::of(cx)),
+            // 168 x 168 at r34, as fractions of the slider ranges.
+            probe_w: (168.0 - 120.0) / 480.0,
+            probe_h: (168.0 - 30.0) / 220.0,
+            probe_r: 34.0 / 84.0,
+            probe_bg: 5,
+            probe_glass: true,
+            probe_bevel: 0.225,
+            probe_tint: false,
+            probe_magnify: 0.585,
+            probe_blur: 0.0,
+            probe_fill: 0.34,
             embedded: false,
         }
     }
@@ -2671,41 +2697,279 @@ impl Gallery {
                 )
                 .into_any_element(),
 
-            // Exercises the fork's backdrop-blur primitive: the card blurs the
-            // striped band painted behind it.
-            "material" => section
-                .child(
-                    div()
-                        .relative()
-                        .w(px(420.0))
-                        .h(px(150.0))
-                        .child(
-                            div()
-                                .absolute()
-                                .inset_0()
-                                .flex()
-                                .flex_row()
-                                .children((0..14).map(|i| {
-                                    div().w(px(30.0)).h_full().bg(if i % 2 == 0 {
-                                        theme.accent
-                                    } else {
-                                        theme.warning
+            // Exercises the fork's backdrop-blur primitive. The backdrop is
+            // big curved edges and text on a dark field, not a tiling pattern:
+            // a lens reads as a *named* edge bending, and a tile whose period
+            // matches the bevel just maps onto itself.
+            "material" => {
+                // The probe: drag the glass over a backdrop, resize it live.
+                // Mirrors the SwiftUI reference harness so the two can be put
+                // side by side on identical content.
+                let bg_names = ["flat", "bars", "h-ruler", "v-ruler", "gradient", "text"];
+                let probe_bg = |i: usize| {
+                    let base = div().absolute().inset_0().overflow_hidden();
+                    match i {
+                        0 => base.bg(gpui::hsla(0.0, 0.0, 0.5, 1.0)),
+                        1 => base.bg(gpui::hsla(0.0, 0.0, 0.5, 1.0)).child(
+                            div().absolute().inset_0().flex().flex_row().children(
+                                (0..6).map(|j| {
+                                    div().flex_1().h_full().bg(match j {
+                                        0 => theme.text_muted,
+                                        1 => theme.warning,
+                                        2 => theme.danger,
+                                        3 => theme.success,
+                                        4 => theme.accent,
+                                        _ => theme.warning_muted,
                                     })
-                                })),
-                        )
-                        .child(
-                            div().absolute().top(px(28.0)).left(px(60.0)).child(
-                                popover::popover_card(&theme)
-                                    .w(px(220.0))
-                                    .child(
-                                        popover::menu_row(&theme, false, Fade::new(view, "mat-a"))
-                                            .child("Blurred"),
-                                    )
-                                    .material(ui::material::MENU_BLUR),
+                                }),
                             ),
                         ),
-                )
-                .into_any_element(),
+                        2 => base.bg(gpui::hsla(0.0, 0.0, 0.5, 1.0)).children((0..30).map(|k| {
+                            div()
+                                .absolute()
+                                .top(px(k as f32 * 12.0))
+                                .left_0()
+                                .right_0()
+                                .h(px(2.0))
+                                .bg(gpui::hsla(0.0, 0.0, 0.0, 0.85))
+                        })),
+                        3 => base.bg(gpui::hsla(0.0, 0.0, 0.5, 1.0)).children((0..70).map(|k| {
+                            div()
+                                .absolute()
+                                .left(px(k as f32 * 12.0))
+                                .top_0()
+                                .bottom_0()
+                                .w(px(2.0))
+                                .bg(gpui::hsla(0.0, 0.0, 0.0, 0.85))
+                        })),
+                        4 => base.bg(theme.accent).child(
+                            div().absolute().inset_0().flex().flex_row().children(
+                                (0..40).map(|k| {
+                                    div().flex_1().h_full().bg(theme.warning.opacity(
+                                        k as f32 / 39.0,
+                                    ))
+                                }),
+                            ),
+                        ),
+                        // What glass actually sits on in an app. Letterforms
+                        // are the honest probe: a displacement shows up as
+                        // text you can no longer read straight.
+                        _ => base.bg(theme.bg).children((0..16).map(|k| {
+                            div()
+                                .absolute()
+                                .top(px(8.0 + k as f32 * 21.0))
+                                .left(px(12.0))
+                                .right(px(12.0))
+                                .text_size(px(15.0))
+                                .text_color(theme.text)
+                                .whitespace_nowrap()
+                                .overflow_hidden()
+                                .child(
+                                    "the quick brown fox jumps over the lazy dog \
+                                     and back again",
+                                )
+                        })),
+                    }
+                };
+                let sigma = self.probe_blur * 60.0;
+                let pw = 120.0 + self.probe_w * 480.0;
+                let ph = 30.0 + self.probe_h * 220.0;
+                let pr = self.probe_r * (pw.min(ph) / 2.0);
+                let chip = |i: usize, on: bool| {
+                    div()
+                        .id(bg_names[i])
+                        .px(px(10.0))
+                        .py(px(4.0))
+                        .rounded(px(Theme::control_radius()))
+                        .text_size(px(12.0))
+                        .text_color(if on { theme.text } else { theme.text_muted })
+                        .bg(if on { theme.glass_hover() } else { theme.bg })
+                        .cursor_pointer()
+                        .child(bg_names[i])
+                        .on_click(cx.listener(move |view, _, _, cx| {
+                            view.probe_bg = i;
+                            cx.notify();
+                        }))
+                };
+                let knob = |id: &'static str, value: f32, label: SharedString| {
+                    div()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap_2()
+                        .child(
+                            div()
+                                .w(px(56.0))
+                                .text_size(px(11.0))
+                                .text_color(theme.text_muted)
+                                .child(label),
+                        )
+                        .child(
+                            div()
+                                .w(px(130.0))
+                                .child(theme.slider(value))
+                                .id(id)
+                                .on_drag(SliderDrag(id.into()), |_, _, _, cx| cx.new(|_| Empty))
+                                .on_drag_move(cx.listener(
+                                    move |view, event: &DragMoveEvent<SliderDrag>, _, cx| {
+                                        let Some(f) = widgets::slider_fraction(event, id, cx)
+                                        else {
+                                            return;
+                                        };
+                                        match id {
+                                            "probe-w" => view.probe_w = f,
+                                            "probe-h" => view.probe_h = f,
+                                            "probe-b" => {
+                                                view.probe_bevel = f;
+                                                theme::set_glass_bevel(f);
+                                            }
+                                            // 0..1 spans -2..+2, so the sweep
+                                            // passes through zero and the lens
+                                            // inverts halfway.
+                                            "probe-m" => {
+                                                view.probe_magnify = f;
+                                                theme::set_glass_magnify(f * 4.0 - 2.0);
+                                            }
+                                            "probe-blur" => view.probe_blur = f,
+                                            "probe-fill" => view.probe_fill = f,
+                                            _ => view.probe_r = f,
+                                        }
+                                        cx.notify();
+                                    },
+                                )),
+                        )
+                };
+                let probe = div()
+                    .flex()
+                    .flex_col()
+                    .gap_2()
+                    .child(
+                        div()
+                            .relative()
+                            .h(px(340.0))
+                            .w_full()
+                            .rounded(px(Theme::panel_radius()))
+                            .overflow_hidden()
+                            .child(probe_bg(self.probe_bg))
+                            .child(floating::panel(
+                                "glass-probe",
+                                &self.probe_at,
+                                point(px(120.0), px(120.0)),
+                                if self.probe_glass {
+                                    let mut glass =
+                                        div().w(px(pw)).h(px(ph)).rounded(px(pr)).glass_effect();
+                                    if sigma > 0.0 {
+                                        glass = glass.blurred(sigma);
+                                    }
+                                    if self.probe_tint {
+                                        glass
+                                            .tint(
+                                                gpui::hsla(0.58, 0.85, 0.55, 1.0)
+                                                    .opacity(self.probe_fill),
+                                            )
+                                            .into_any_element()
+                                    } else {
+                                        glass.into_any_element()
+                                    }
+                                } else {
+                                    div()
+                                        .w(px(pw))
+                                        .h(px(ph))
+                                        .rounded(px(pr))
+                                        .bg(theme.glass_overlay().opacity(self.probe_fill))
+                                        .material(if sigma > 0.0 {
+                                            sigma
+                                        } else {
+                                            ui::material::MENU_BLUR
+                                        })
+                                        .into_any_element()
+                                },
+                            )),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .gap_3()
+                            .flex_wrap()
+                            .children((0..6).map(|i| chip(i, self.probe_bg == i)))
+                            .child(
+                                div()
+                                    .id("probe-surface")
+                                    .px(px(10.0))
+                                    .py(px(4.0))
+                                    .rounded(px(Theme::control_radius()))
+                                    .text_size(px(12.0))
+                                    .text_color(theme.text)
+                                    .bg(theme.glass_hover())
+                                    .cursor_pointer()
+                                    .child(if self.probe_glass { "glass" } else { "frosted" })
+                                    .on_click(cx.listener(|view, _, _, cx| {
+                                        view.probe_glass = !view.probe_glass;
+                                        cx.notify();
+                                    })),
+                            )
+                            .child(
+                                div()
+                                    .id("probe-tint")
+                                    .px(px(10.0))
+                                    .py(px(4.0))
+                                    .rounded(px(Theme::control_radius()))
+                                    .text_size(px(12.0))
+                                    .text_color(if self.probe_tint {
+                                        theme.text
+                                    } else {
+                                        theme.text_muted
+                                    })
+                                    .bg(if self.probe_tint {
+                                        theme.glass_hover()
+                                    } else {
+                                        theme.bg
+                                    })
+                                    .cursor_pointer()
+                                    .child("tint")
+                                    .on_click(cx.listener(|view, _, _, cx| {
+                                        view.probe_tint = !view.probe_tint;
+                                        cx.notify();
+                                    })),
+                            )
+                            .child(knob("probe-w", self.probe_w, format!("w {}", pw as i32).into()))
+                            .child(knob("probe-h", self.probe_h, format!("h {}", ph as i32).into()))
+                            .child(knob("probe-r", self.probe_r, format!("r {}", pr as i32).into()))
+                            .child(knob(
+                                "probe-b",
+                                self.probe_bevel,
+                                format!("bevel {:.2}", self.probe_bevel).into(),
+                            ))
+                            .child(knob(
+                                "probe-m",
+                                self.probe_magnify,
+                                format!("mag {:+.2}", self.probe_magnify * 4.0 - 2.0).into(),
+                            ))
+                            .child(knob(
+                                "probe-blur",
+                                self.probe_blur,
+                                format!("blur {}", sigma as i32).into(),
+                            ))
+                            .child(knob(
+                                "probe-fill",
+                                self.probe_fill,
+                                format!("fill {:.2}", self.probe_fill).into(),
+                            )),
+                    );
+
+                section
+                    .child(hint(
+                        &theme,
+                        "Drag the glass, resize it, switch what is behind it. \
+                         Frosted blurs what it covers; glass lifts it and lenses \
+                         at the rim. Both read very differently depending on the \
+                         backdrop, which is what the switcher is for.",
+                    ))
+                    .child(probe)
+                    .into_any_element()
+            }
 
             "alerts" => section
                 .child(theme.error_strip("Something went wrong."))

--- a/apps/gallery/src/lib.rs
+++ b/apps/gallery/src/lib.rs
@@ -3361,6 +3361,7 @@ fn color_groups(theme: &Theme) -> Vec<(&'static str, Vec<(&'static str, gpui::Hs
                 ("element_active", theme.element_active),
                 ("selection", theme.selection),
                 ("caret", theme.caret),
+                ("ring", theme.ring),
                 ("solid", theme.solid),
             ],
         ),

--- a/apps/gallery/src/lib.rs
+++ b/apps/gallery/src/lib.rs
@@ -10,7 +10,7 @@ use gpui::{
     AnyElement, App, Axis, Context, DragMoveEvent, Empty, Entity, KeyBinding, SharedString, Window,
     actions, div, prelude::*, px, relative,
 };
-use motion::{Fade, Painter};
+use motion::{AppExt as _, Fade, Painter};
 use rail::{Rail, Selected};
 use std::{cell::Cell, collections::HashSet, rc::Rc};
 use theme::{
@@ -965,6 +965,18 @@ impl Gallery {
         cx.notify();
     }
 
+    /// Show or hide the meter, and tell the app what that means for animation.
+    ///
+    /// A meter that stops the moment you look at something else cannot report
+    /// what the app costs in the background, which is the case worth catching.
+    /// So while it is up the app keeps animating unfocused — the reading and
+    /// the thing being read are the same cost, and that is the honest trade.
+    fn show_stats(&mut self, shown: bool, cx: &mut Context<Self>) {
+        self.stats_shown = shown;
+        cx.set_pause_when_inactive(!shown);
+        cx.notify();
+    }
+
     /// The browser, opened on one section — `cargo run -p gallery -- editor`.
     /// Falls back to the default page when the key is not in the catalog, so a
     /// stale link lands somewhere useful instead of on an empty pane.
@@ -1233,8 +1245,7 @@ impl Gallery {
                     .p(px(4.0))
                     .cursor_pointer()
                     .on_click(cx.listener(|view, _, _, cx| {
-                        view.stats_shown = !view.stats_shown;
-                        cx.notify();
+                        view.show_stats(!view.stats_shown, cx);
                     }))
                     .child(icons::icon(icons::CPU).size(px(15.0)).text_color(
                         if self.stats_shown {
@@ -2491,7 +2502,9 @@ impl Gallery {
             "stats" => {
                 // The page documents the box in the corner, so the box has to
                 // be there while you read it.
-                self.stats_shown = true;
+                if !self.stats_shown {
+                    self.show_stats(true, cx);
+                }
                 section
                     .child(hint(
                         &theme,
@@ -2530,6 +2543,14 @@ impl Gallery {
                         "CPU is the whole process — user plus system, every thread — \
                          as a percentage of one core, the figure Activity Monitor \
                          prints. The web build has no such call and reads —.",
+                    ))
+                    .child(hint(
+                        &theme,
+                        "While the meter is up this app keeps animating when you \
+                         switch away from it, so the numbers carry on where they \
+                         would otherwise freeze. That is the cost being measured, \
+                         paid on purpose: switch the meter off and the app parks \
+                         itself in the background again.",
                     ))
                     .into_any_element()
             }

--- a/apps/gallery/src/lib.rs
+++ b/apps/gallery/src/lib.rs
@@ -2500,21 +2500,26 @@ impl Gallery {
                 .into_any_element(),
 
             "stats" => {
-                // The page documents the box in the corner, so the box has to
-                // be there while you read it.
+                // Showing the page is showing the meter: it moves out of the
+                // window's corner and into the column here, so the page
+                // documents a component you are looking at rather than one it
+                // describes. One instance either way — two of them would each
+                // count the other's frames.
                 if !self.stats_shown {
                     self.show_stats(true, cx);
                 }
                 section
                     .child(hint(
                         &theme,
-                        "The meter in the corner is measuring this window. At rest \
-                         it reads 0 — nothing on screen is asking for a frame, and \
-                         the meter's own two-a-second tick is the one draw it does \
-                         not count. Mount the spinner and read what one animation \
-                         costs a whole window: every frame it asks for is a full \
-                         redraw, and the number is the rate it is really getting.",
+                        "This is the meter, measuring the window it is sitting in. \
+                         At rest it reads 0 — nothing on screen is asking for a \
+                         frame, and its own two-a-second tick is the one draw it \
+                         does not count. Mount the spinner and read what one \
+                         animation costs a whole window: every frame it asks for is \
+                         a full redraw, and the number is the rate it is really \
+                         getting.",
                     ))
+                    .child(self.stats.clone())
                     .child(
                         row()
                             .child(
@@ -3746,7 +3751,9 @@ impl Render for Gallery {
             .text_color(theme.text)
             .text_size(px(14.0))
             .child(content)
-            .when(self.stats_shown, |root| {
+            // Not on the page that documents it: that page mounts the meter in
+            // its own column, and the entity can only be in one place.
+            .when(self.stats_shown && section.key != "stats", |root| {
                 // Home is read off the viewport rather than stored, so the
                 // corner it opens in is the corner of *this* window.
                 let viewport = window.viewport_size();

--- a/apps/gallery/src/lib.rs
+++ b/apps/gallery/src/lib.rs
@@ -40,7 +40,8 @@ use ui::{
     tree::{self, Direction, Move},
     widgets,
     widgets::{
-        ButtonStyle, Buttons, Content, Controls, Layout, Scaffolding, SliderDrag, SplitDrag, Status,
+        ButtonStyle, Buttons, Content, Controls, Layout, Scaffolding, SliderDrag, SplitDrag,
+        SplitStyle, Status,
     },
 };
 
@@ -2308,7 +2309,12 @@ impl Gallery {
                             ))))
                             .child(
                                 theme
-                                    .split_handle(Axis::Horizontal, self.split_dragging)
+                                    .split_handle(
+                                        Axis::Horizontal,
+                                        SplitStyle::Line {
+                                            dragging: self.split_dragging,
+                                        },
+                                    )
                                     .id("split-handle")
                                     .on_drag(SplitDrag, |_, _, _, cx| cx.new(|_| Empty)),
                             )

--- a/crates/editor/src/editor/image.rs
+++ b/crates/editor/src/editor/image.rs
@@ -15,7 +15,11 @@ use gpui::{
 };
 use markdown::{Block, BlockKind, Cursor, Part, Selection, Text};
 use theme::Theme;
-use ui::{input::TextField, popover, widgets::Layout as _};
+use ui::{
+    input::TextField,
+    popover,
+    widgets::{Layout as _, SplitStyle},
+};
 
 use crate::{
     editor::{
@@ -372,7 +376,7 @@ impl Editor {
         let picture = self.picture_box(ix, current)?;
         Some(
             theme
-                .split_handle(Axis::Horizontal, dragging)
+                .split_handle(Axis::Horizontal, SplitStyle::Line { dragging })
                 .id("image-resize-handle")
                 .absolute()
                 .left(picture.origin.x + picture.size.width - px(4.5))

--- a/crates/motion/src/app.rs
+++ b/crates/motion/src/app.rs
@@ -1,0 +1,64 @@
+//! [`AppExt`] — the app-level motion settings, reached on the `App` itself the
+//! way component groups are reached on the theme.
+//!
+//! What belongs here is a setting the `App` holds. [`crate::set_speed`] does
+//! not: the catalog's timelines are read from free functions deep inside
+//! element builders that have no `cx` to hand, which is why speed is a
+//! process-wide mirror instead.
+
+use gpui::{App, Global};
+
+/// Whether animation stops while the app is not frontmost. Absent means on —
+/// a global nobody installed is the default, not the opposite of it.
+struct PauseWhenInactive(bool);
+
+impl Global for PauseWhenInactive {}
+
+/// The motion settings an app carries.
+///
+/// ```ignore
+/// use motion::AppExt as _;
+///
+/// cx.set_pause_when_inactive(false);   // a HUD that must keep moving unfocused
+/// ```
+pub trait AppExt {
+    /// gpui snaps every `with_animation` element when this is set — end state
+    /// for oneshots, rest state for loops — and schedules no frames.
+    fn reduced_motion(&self) -> bool;
+
+    fn set_reduced_motion(&mut self, reduced: bool);
+
+    /// Whether animation stops while the app is not frontmost. On by default.
+    fn pause_when_inactive(&self) -> bool;
+
+    /// An app in the background that keeps animating is spending a core on
+    /// frames nobody is looking at. Nothing below this stops on its own: one
+    /// spinner in a backgrounded window held 30fps and 22% of a core
+    /// indefinitely (2026-08, debug build, M-series laptop), against 2% with
+    /// this on. Turn it off for a window that must keep moving while something
+    /// else has focus — a side panel, a floating HUD.
+    ///
+    /// The claim is refused rather than cancelled, so nothing has to resume it:
+    /// gpui refreshes a window when it becomes active, and the render that
+    /// follows takes the claim again.
+    fn set_pause_when_inactive(&mut self, pause: bool);
+}
+
+impl AppExt for App {
+    fn reduced_motion(&self) -> bool {
+        self.reduce_motion()
+    }
+
+    fn set_reduced_motion(&mut self, reduced: bool) {
+        self.set_reduce_motion(reduced);
+    }
+
+    fn pause_when_inactive(&self) -> bool {
+        self.try_global::<PauseWhenInactive>()
+            .is_none_or(|pause| pause.0)
+    }
+
+    fn set_pause_when_inactive(&mut self, pause: bool) {
+        self.set_global(PauseWhenInactive(pause));
+    }
+}

--- a/crates/motion/src/lib.rs
+++ b/crates/motion/src/lib.rs
@@ -16,9 +16,9 @@
 //!
 //! Reduced motion: gpui's `App::reduce_motion` flag is honored *automatically* by
 //! every `with_animation` element — oneshot animations snap to their end state,
-//! repeating ones to their start state, and no frames are scheduled. The
-//! [`set_reduced_motion`]/[`reduced_motion`] wrappers make it a single global
-//! switch; pure helpers take the flag explicitly where they run outside elements.
+//! repeating ones to their start state, and no frames are scheduled.
+//! [`AppExt`] carries that switch and the rest of the app-level settings; pure
+//! helpers take the flag explicitly where they run outside elements.
 //!
 //! translateY is implemented as a relative-position `top` inset: taffy applies
 //! relative insets after layout, so — like a CSS transform — siblings never move.
@@ -44,7 +44,10 @@ use gpui::{
 /// [`pulse_delta`], which leases the view instead of pinning the window.
 pub use gpui::AnimationExt;
 
+mod app;
 pub mod phase;
+
+pub use app::AppExt;
 
 // ---------------------------------------------------------------------------
 // The clock — one leased drive for everything that repeats
@@ -179,6 +182,12 @@ impl From<EntityId> for Painter {
 }
 
 fn lease(view: EntityId, fps: f32, until: Duration, cx: &mut App) {
+    // Nobody is looking. Refusing the claim is enough to stop the clock: the
+    // ones already held lapse, the loop runs out of work and parks, and the
+    // refresh gpui does on activation brings the renders that claim again.
+    if cx.pause_when_inactive() && cx.active_window().is_none() {
+        return;
+    }
     let now = cx.background_executor().now();
     let period = Duration::from_secs_f32(1.0 / fps.clamp(1.0, 240.0));
     let clock = cx.default_global::<PulseClock>();
@@ -739,7 +748,7 @@ pub fn set_hover(fade: &Fade, hovered: bool, reduced: bool) {
 /// event-dispatch context, where `Window::current_view()` asserts.
 pub fn hover_listener(fade: Fade) -> impl Fn(&bool, &mut Window, &mut App) + 'static {
     move |hovered, _window, cx| {
-        set_hover(&fade, *hovered, reduced_motion(cx));
+        set_hover(&fade, *hovered, cx.reduced_motion());
         fade.painter.lease(HOVER_FPS, HoverFades::duration(), cx);
     }
 }
@@ -829,15 +838,4 @@ pub fn set_speed(scale: f32) {
 pub fn lock_speed() -> std::sync::MutexGuard<'static, ()> {
     static SPEED_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     SPEED_LOCK.lock().unwrap_or_else(|e| e.into_inner())
-}
-
-/// Global reduced-motion flag. gpui snaps every `with_animation` element when
-/// set (end state for oneshots, rest state for loops) and schedules no frames.
-pub fn set_reduced_motion(cx: &mut App, reduced: bool) {
-    cx.set_reduce_motion(reduced);
-}
-
-/// Read the global reduced-motion flag.
-pub fn reduced_motion(cx: &App) -> bool {
-    cx.reduce_motion()
 }

--- a/crates/theme/src/brand.rs
+++ b/crates/theme/src/brand.rs
@@ -108,7 +108,7 @@ impl Brand {
         // danger, warning, success — is semantic and keeps it. Translucent ink
         // is skipped because it paints over whatever is beneath it, which is
         // tinted already.
-        let tokens: [&mut Hsla; 38] = [
+        let tokens: [&mut Hsla; 39] = [
             &mut theme.bg,
             &mut theme.surface,
             &mut theme.surface_raised,
@@ -141,6 +141,7 @@ impl Brand {
             &mut theme.selection,
             &mut theme.cursor,
             &mut theme.caret,
+            &mut theme.ring,
             &mut theme.danger_strong,
             &mut theme.code_text,
             &mut theme.code_wash,

--- a/crates/theme/src/lib.rs
+++ b/crates/theme/src/lib.rs
@@ -42,6 +42,7 @@ mod paint;
 mod theme;
 
 pub use brand::{BASE_COLORS, Brand, Tint, brand, set_brand};
+
 pub use color::{
     contrast_ratio, flatten, grey, hsl_to_rgb, lightness, mix, neutral, oklch, oklch_to_srgb,
     relative_luminance, rgb_to_hsl, tint,
@@ -51,7 +52,7 @@ pub use paint::{
     card_selected_shadows, current_appearance, glass_selected_bg, glass_selected_shadows, hairline,
     ink, lock_appearance, scrim, set_current_appearance, theme_generation, user_bubble_bg, wash,
 };
-pub use theme::{HighlightKind, SyntaxPalette, Theme, set_palette};
+pub use theme::{HighlightKind, SyntaxPalette, Theme, set_glass_bevel, set_glass_magnify, set_palette};
 
 /// The carrier seam for catalog traits: any type holding a [`Theme`] exposes
 /// it through this one method, and every component group

--- a/crates/theme/src/theme/glass.rs
+++ b/crates/theme/src/theme/glass.rs
@@ -109,6 +109,42 @@ impl Theme {
         }
     }
 
+    /// The lift behind liquid glass (`bezel::ui::material::Glass::glass_effect`).
+    ///
+    /// White, and composited *additively*: measured off `NSGlassEffectView`
+    /// over flat fields at five luminances (2026-08), its interior comes out
+    /// at `1.042 * backdrop + 19/255` — a veil that brightens whatever is
+    /// behind it, at every level, rather than a scrim that dims it.
+    pub fn glass_clear(&self) -> Hsla {
+        gpui::hsla(0.0, 0.0, 1.0, 0.075)
+    }
+
+    /// How far in from the rim the refracting profile reaches, given `extent`
+    /// — the shape's smaller side.
+    ///
+    /// The interior is a straight pass-through: measurement of Apple's own
+    /// output shows the backdrop unperturbed to within a hundredth of a point
+    /// below the band, with every displacement inside it.
+    pub fn glass_bevel(extent: f32) -> f32 {
+        extent * layout::bevel()
+    }
+
+    /// Displacement amplitude of the glass lens, signed: positive magnifies
+    /// the interior and compresses what it displaces into the rim, negative
+    /// inverts it. 0.34 is what a single glass surface at eta 1.52 bends by,
+    /// which is where the physical model this replaced happened to land;
+    /// the number is a knob now rather than an index.
+    pub fn glass_magnify() -> f32 {
+        layout::magnify()
+    }
+
+    /// Per-channel spread of the displacement — the chromatic fringe at the
+    /// rim. Sub-percent: the fringe scales with the displacement, and at the
+    /// lens amplitude a wider spread reads as rainbow rather than glass.
+    pub fn glass_dispersion() -> f32 {
+        0.005
+    }
+
     /// The standard modal backdrop — see [`scrim`](crate::paint::scrim).
     pub fn scrim(&self) -> Hsla {
         paint::scrim_for(self.appearance, paint::SCRIM_ALPHA_DARK)

--- a/crates/theme/src/theme/layout.rs
+++ b/crates/theme/src/theme/layout.rs
@@ -66,7 +66,8 @@ impl Theme {
     /// Opaque off macOS: Linux and Windows get no compositor-blur guarantee,
     /// and a merely transparent window would show raw desktop through the
     /// sidebar. An app that knows its compositor sets the brand field anyway.
-    pub const GLASS_ALPHA: f32 = if cfg!(target_os = "macos") { 0.80 } else { 1.0 };
+    pub const GLASS_ALPHA: f32 =
+        if cfg!(any(target_os = "macos", target_family = "wasm")) { 0.80 } else { 1.0 };
     /// Main-panel header height (the reference `h-11`) — in-card headers (changes pane).
     pub const HEADER_HEIGHT: f32 = 44.0;
     /// The unified window titlebar (traffic lights + cluster + tabs). Content

--- a/crates/theme/src/theme/layout.rs
+++ b/crates/theme/src/theme/layout.rs
@@ -11,6 +11,16 @@ static BASE: AtomicU32 = AtomicU32::new(Theme::BASE_RADIUS.to_bits());
 /// The branded frost alpha behind [`Theme::glass`], as raw `f32` bits.
 static FROST: AtomicU32 = AtomicU32::new(Theme::GLASS_ALPHA.to_bits());
 
+/// What share of a glass shape's smaller side the lens profile spans.
+/// Measured off SwiftUI's `.glassEffect(.clear)` (2026-08): on a 460x120
+/// capsule the ruler behind it is displaced over the outer 27pt and is exactly
+/// unperturbed below that — a bezel with a flat interior, not a lens across
+/// the whole body.
+static BEVEL: AtomicU32 = AtomicU32::new(0.225f32.to_bits());
+
+/// The lens amplitude behind [`Theme::glass_magnify`], as raw `f32` bits.
+static MAGNIFY: AtomicU32 = AtomicU32::new(0.34f32.to_bits());
+
 /// Point the radius accessors at a base. Called by
 /// [`Theme::install`](crate::theme::Theme::install).
 pub(crate) fn set_base_radius(radius: f32) {
@@ -21,6 +31,24 @@ pub(crate) fn set_base_radius(radius: f32) {
 /// [`Theme::install`](crate::theme::Theme::install).
 pub(crate) fn set_frost(alpha: f32) {
     FROST.store(alpha.to_bits(), Ordering::Relaxed);
+}
+
+/// Point [`Theme::glass_bevel`] at a share of the inradius.
+pub fn set_glass_bevel(share: f32) {
+    BEVEL.store(share.to_bits(), Ordering::Relaxed);
+}
+
+/// Point [`Theme::glass_magnify`] at an amplitude. Signed.
+pub fn set_glass_magnify(amount: f32) {
+    MAGNIFY.store(amount.to_bits(), Ordering::Relaxed);
+}
+
+pub(crate) fn magnify() -> f32 {
+    f32::from_bits(MAGNIFY.load(Ordering::Relaxed))
+}
+
+pub(crate) fn bevel() -> f32 {
+    f32::from_bits(BEVEL.load(Ordering::Relaxed))
 }
 
 pub(crate) fn frost() -> f32 {

--- a/crates/theme/src/theme/mod.rs
+++ b/crates/theme/src/theme/mod.rs
@@ -11,6 +11,7 @@ mod palettes;
 mod syntax;
 
 pub use install::set_palette;
+pub use layout::{set_glass_bevel, set_glass_magnify};
 pub use syntax::{HighlightKind, SyntaxPalette};
 
 /// The app theme. Two concrete instances — [`Theme::dark`] and [`Theme::light`].

--- a/crates/theme/src/theme/mod.rs
+++ b/crates/theme/src/theme/mod.rs
@@ -139,13 +139,16 @@ pub struct Theme {
     pub selection: Hsla,
     /// Terminal block cursor.
     pub cursor: Hsla,
-    /// Text caret, and the focus ring that shares its weight.
+    /// Text caret.
     ///
     /// The body text colour, because that is what a caret is: the next glyph,
     /// before you type it. It was a sampled blue once — carried over from the
     /// app this library was extracted from, derived from nothing here — which
     /// is why a caret in a plain paragraph arrived tinted.
     pub caret: Hsla,
+    /// Keyboard focus ring — a hairline, so it marks the control without
+    /// restating the label inside it.
+    pub ring: Hsla,
     /// Destructive-action button fill (danger plate, carries [`Self::on_accent`]).
     pub danger_strong: Hsla,
 

--- a/crates/theme/src/theme/palettes.rs
+++ b/crates/theme/src/theme/palettes.rs
@@ -46,6 +46,7 @@ impl Theme {
             selection: hsla(0.66, 0.6, 0.55, 0.35),
             cursor: hsla(0.0, 0.0, 1.0, 0.35),
             caret: color::neutral(0.922), // the body text colour
+            ring: paint::hairline_for(Appearance::Dark, 0.35), // ~2.5× border_strong
             danger_strong: color::oklch(0.58, 0.16, 25.0),
             code_text: color::neutral(0.94), // near-white, a shade above body text
             code_wash: hsla(0.0, 0.0, 1.0, 0.08), // white/8
@@ -126,6 +127,7 @@ impl Theme {
             selection: hsla(0.66, 0.75, 0.62, 0.28),
             cursor: hsla(0.0, 0.0, 0.0, 0.55),
             caret: color::neutral(0.25), // the body text colour
+            ring: paint::hairline_for(Appearance::Light, 0.35),
             danger_strong: color::oklch(0.51, 0.20, 25.0),
             code_text: color::neutral(0.18), // near-black, a shade under body text
             code_wash: hsla(0.0, 0.0, 0.0, 0.06), // black/6

--- a/crates/ui/src/control_bar.rs
+++ b/crates/ui/src/control_bar.rs
@@ -9,7 +9,7 @@
 //! Two things it exists to get right.
 //!
 //! **The blur corners follow the border.** [`Shape`] rounds the bar, and
-//! [`crate::material::Frosted::material`] cuts the backdrop blur to the rounding it finds — a
+//! [`crate::material::Glass::material`] cuts the backdrop blur to the rounding it finds — a
 //! blur squarer than its border frosts the corners outside it.
 //!
 //! **The centre is centred on the bar, not on what the clusters leave.** The
@@ -44,7 +44,7 @@
 use gpui::{AnyElement, IntoElement, ParentElement as _, Styled as _, div, px};
 use theme::{Theme, hairline};
 
-use crate::material::{self, Frosted as _};
+use crate::material::{self, Glass as _};
 
 /// Height of the bar, and so half the radius of a [`Shape::Pill`]. One number
 /// rather than a parameter: a stadium's radius has to be derived from it for

--- a/crates/ui/src/date.rs
+++ b/crates/ui/src/date.rs
@@ -522,7 +522,7 @@ fn day_cell(
         // grid can never nudge a single cell by a pixel.
         .border_1()
         .border_color(if cursor {
-            theme.caret
+            theme.ring
         } else {
             widgets::RING_SLOT
         })

--- a/crates/ui/src/focus.rs
+++ b/crates/ui/src/focus.rs
@@ -91,7 +91,7 @@ pub fn traversal(el: Div) -> Div {
 /// let `enter`/`space` press it.
 ///
 /// The ring is the same one [`crate::input::TextField`] paints — the border in
-/// [`Theme::caret`] — so a focused button and a focused field read alike.
+/// [`Theme::ring`] — so a focused button and a focused field read alike.
 ///
 /// Keyboard focus only, like CSS `:focus-visible`. A control also takes focus
 /// when clicked, and a ring that landed on it there would outline a slider for
@@ -116,5 +116,5 @@ pub fn focusable(theme: &Theme, handle: &FocusHandle, el: Div) -> Div {
     let handle = handle.clone().tab_stop(true);
     el.key_context(CONTROL_KEY_CONTEXT)
         .track_focus(&handle)
-        .focus_visible(|style| style.border_color(theme.caret))
+        .focus_visible(|style| style.border_color(theme.ring))
 }

--- a/crates/ui/src/input.rs
+++ b/crates/ui/src/input.rs
@@ -1298,7 +1298,7 @@ impl Render for TextField {
             .bg(theme.input_bg)
             .border_1()
             .border_color(if self.focus_handle.is_focused(_window) {
-                theme.caret
+                theme.ring
             } else {
                 theme.border
             })

--- a/crates/ui/src/material.rs
+++ b/crates/ui/src/material.rs
@@ -10,10 +10,13 @@
 //! `Window::paint_backdrop_blur` from our gpui fork (macOS Metal only);
 //! elsewhere the primitive is ignored and the glass reads as the theme's
 //! translucent tint over the OS window blur.
+//!
+//! [`Glass::glass_effect`] is the liquid surface: a bevel at the rim that
+//! refracts the backdrop, and a fill of its own.
 
 use gpui::{
     AbsoluteLength, AnyElement, App, Bounds, Corners, Element, GlobalElementId, InspectorElementId,
-    IntoElement, LayoutId, Pixels, Styled, Window, px,
+    IntoElement, LayoutId, Pixels, Styled, Window, fill, px,
 };
 
 use theme::Theme;
@@ -42,41 +45,119 @@ pub fn material(corner_radius: f32, blur_radius: f32, child: impl IntoElement) -
             bottom_left: radius,
         },
         blur_radius,
+        glass: false,
+        tint: None,
+        blur_override: None,
         child: child.into_any_element(),
     }
 }
 
-/// Frost this card at the corner radius it already carries.
-///
-/// The radius comes off the element's own style, so a caller chaining its own
-/// rounding — `card.rounded(px(4.0)).material(MENU_BLUR)` — gets a blur cut to
-/// the corners it just asked for.
-pub trait Frosted: Styled + IntoElement + Sized {
+/// The backdrop surfaces, on any element carrying a corner radius.
+pub trait Glass: Styled + IntoElement + Sized {
+    /// Frost this card at the corner radius it already carries.
+    ///
+    /// The radius comes off the element's own style, so a caller chaining its
+    /// own rounding — `card.rounded(px(4.0)).material(MENU_BLUR)` — gets a blur
+    /// cut to the corners it just asked for.
     fn material(mut self, blur_radius: f32) -> Material {
-        let square = AbsoluteLength::from(px(0.0));
-        let radii = &self.style().corner_radii;
-        let corners = Corners {
-            top_left: radii.top_left.unwrap_or(square),
-            top_right: radii.top_right.unwrap_or(square),
-            bottom_right: radii.bottom_right.unwrap_or(square),
-            bottom_left: radii.bottom_left.unwrap_or(square),
-        };
+        Material {
+            corners: corners_of(&mut self),
+            blur_radius,
+            glass: false,
+            tint: None,
+            blur_override: None,
+            child: self.into_any_element(),
+        }
+    }
+
+    /// Paint this card as liquid glass — SwiftUI's `Glass.clear`: a refracting
+    /// bevel at the rim, a lit edge, and [`Theme::glass_clear`]'s dimming.
+    ///
+    /// Blur, bevel and tint all come off [`Theme`], and the shape off the
+    /// card's own rounding: the lens dies if any of the three is wrong.
+    ///
+    /// It clears the card's `bg`, since the lens paints the fill. Where the
+    /// lens cannot run — every renderer but macOS Metal — it paints the frosted
+    /// tint instead, so the surface is never invisible.
+    fn glass_effect(mut self) -> Material {
+        let corners = corners_of(&mut self);
+        // The lens paints the fill, so the card's own is dropped here rather
+        // than at the call site: painting both is what buries the lens, and a
+        // caller who has to remember that is a caller who will forget.
+        self.style().background = None;
         Material {
             corners,
-            blur_radius,
+            blur_radius: 0.0,
+            glass: true,
+            tint: None,
+            blur_override: None,
             child: self.into_any_element(),
         }
     }
 }
 
-impl<E: Styled + IntoElement> Frosted for E {}
+/// The rounding an element already carries, as the blur needs it.
+fn corners_of(styled: &mut impl Styled) -> Corners<AbsoluteLength> {
+    let square = AbsoluteLength::from(px(0.0));
+    let radii = &styled.style().corner_radii;
+    Corners {
+        top_left: radii.top_left.unwrap_or(square),
+        top_right: radii.top_right.unwrap_or(square),
+        bottom_right: radii.bottom_right.unwrap_or(square),
+        bottom_left: radii.bottom_left.unwrap_or(square),
+    }
+}
+
+impl<E: Styled + IntoElement> Glass for E {}
 
 pub struct Material {
+    /// The glass's own tint, when the caller wants one. `None` is
+    /// [`Theme::glass_clear`]'s neutral lift.
+    tint: Option<gpui::Hsla>,
+    /// Frost under the lens. Glass does not frost by default.
+    blur_override: Option<f32>,
     /// Held unresolved: a rem-rounded card only becomes pixels against the
     /// window's rem size, which paint is the first place to have.
     corners: Corners<AbsoluteLength>,
     blur_radius: f32,
+    glass: bool,
     child: AnyElement,
+}
+
+/// Whether this build has the backdrop-blur primitive behind it — the Metal
+/// renderer is the only one that reads it off the scene.
+const LENSED: bool = cfg!(target_os = "macos");
+
+impl Material {
+    /// Tint the glass — SwiftUI's `Glass.tint(_:)`, for a control important
+    /// enough to carry colour. Pass the colour at the coverage you want; it
+    /// stands in for [`Theme::glass_clear`]'s neutral lift rather than adding
+    /// to it, so a heavy alpha reads as paint and a light one as glass.
+    ///
+    /// A plain material's fill is still its caller's, and this does not
+    /// reach it.
+    pub fn tint(mut self, color: gpui::Hsla) -> Self {
+        self.tint = Some(color);
+        self
+    }
+
+    /// Frost the backdrop under the lens. Glass is clear by default — seeing
+    /// through is the point — but a surface that has to carry dense content
+    /// can buy legibility with a sigma of its own.
+    pub fn blurred(mut self, sigma: f32) -> Self {
+        self.blur_override = Some(sigma);
+        self
+    }
+
+    /// The card's rounding in pixels, which only a rem size resolves.
+    fn corners(&self, rem: Pixels) -> Corners<Pixels> {
+        Corners {
+            top_left: self.corners.top_left.to_pixels(rem),
+            top_right: self.corners.top_right.to_pixels(rem),
+            bottom_right: self.corners.bottom_right.to_pixels(rem),
+            bottom_left: self.corners.bottom_left.to_pixels(rem),
+        }
+    }
 }
 
 impl Element for Material {
@@ -123,16 +204,44 @@ impl Element for Material {
         window: &mut Window,
         cx: &mut App,
     ) {
-        if Theme::of(cx).is_glass() {
-            let rem = window.rem_size();
-            let corners = Corners {
-                top_left: self.corners.top_left.to_pixels(rem),
-                top_right: self.corners.top_right.to_pixels(rem),
-                bottom_right: self.corners.bottom_right.to_pixels(rem),
-                bottom_left: self.corners.bottom_left.to_pixels(rem),
+        let theme = Theme::of(cx);
+        // The backdrop-blur primitive is macOS Metal's alone. Glass moved the
+        // card's fill into it, so anywhere it will not run the fill is painted
+        // here instead, or the card comes out a hole with rows floating in it.
+        if self.glass && !(LENSED && theme.is_glass()) {
+            let backing = if theme.is_glass() {
+                theme.glass_overlay()
+            } else {
+                theme.surface_overlay
             };
+            let corners = self.corners(window.rem_size());
+            window.paint_quad(fill(bounds, backing).corner_radii(corners));
+        }
+        if theme.is_glass() {
+            // Only glass tints: a plain material paints what it always has,
+            // and its caller still owns the fill.
+            let (bevel, tint) = if self.glass {
+                let extent = bounds.size.width.min(bounds.size.height);
+                (
+                    Theme::glass_bevel(f32::from(extent)),
+                    self.tint.unwrap_or_else(|| theme.glass_clear()),
+                )
+            } else {
+                (0.0, gpui::transparent_black())
+            };
+            let corners = self.corners(window.rem_size());
             window.paint_layer(bounds, |window| {
-                window.paint_backdrop_blur(bounds, corners, px(self.blur_radius));
+                window.paint_backdrop_blur(
+                    bounds,
+                    corners,
+                    gpui::GlassEffect {
+                        blur_radius: px(self.blur_override.unwrap_or(self.blur_radius)),
+                        lens: px(bevel),
+                        magnify: Theme::glass_magnify(),
+                        dispersion: Theme::glass_dispersion(),
+                        tint,
+                    },
+                );
                 self.child.paint(window, cx);
             });
         } else {

--- a/crates/ui/src/material.rs
+++ b/crates/ui/src/material.rs
@@ -124,9 +124,17 @@ pub struct Material {
     child: AnyElement,
 }
 
-/// Whether this build has the backdrop-blur primitive behind it — the Metal
-/// renderer is the only one that reads it off the scene.
-const LENSED: bool = cfg!(target_os = "macos");
+/// Whether this build has the backdrop-blur primitive behind it. Metal reads it
+/// off the scene, and so does wgpu now that the fork implements it there —
+/// which is why this tracks the gpui in use rather than the platform alone.
+const LENSED: bool = cfg!(any(target_os = "macos", target_family = "wasm"));
+
+/// Whether [`Glass::glass_effect`] will actually refract here, rather than
+/// falling back to the flat backdrop tint. The primitive is macOS Metal's, and
+/// an opaque appearance has nothing behind it to lens.
+pub fn lensed(theme: &Theme) -> bool {
+    LENSED && theme.is_glass()
+}
 
 impl Material {
     /// Tint the glass — SwiftUI's `Glass.tint(_:)`, for a control important
@@ -206,16 +214,16 @@ impl Element for Material {
     ) {
         let theme = Theme::of(cx);
         // The backdrop-blur primitive is macOS Metal's alone. Glass moved the
-        // card's fill into it, so anywhere it will not run the fill is painted
-        // here instead, or the card comes out a hole with rows floating in it.
-        if self.glass && !(LENSED && theme.is_glass()) {
-            let backing = if theme.is_glass() {
-                theme.glass_overlay()
-            } else {
-                theme.surface_overlay
-            };
+        // card's fill into it, so anywhere the lens will not run the fill is
+        // painted here — the overlay tint, so the card degrades to a surface
+        // with the page showing through rather than to an opaque slab.
+        if self.glass && !lensed(theme) {
             let corners = self.corners(window.rem_size());
-            window.paint_quad(fill(bounds, backing).corner_radii(corners));
+            window.paint_quad(fill(bounds, theme.glass_overlay()).corner_radii(corners));
+            // The lens is what would have carried the caller's colour.
+            if let Some(tint) = self.tint {
+                window.paint_quad(fill(bounds, tint).corner_radii(corners));
+            }
         }
         if theme.is_glass() {
             // Only glass tints: a plain material paints what it always has,

--- a/crates/ui/src/palette.rs
+++ b/crates/ui/src/palette.rs
@@ -28,7 +28,7 @@ use theme::Theme;
 
 use crate::{
     input::{self, TextField},
-    material::Frosted as _,
+    material::Glass as _,
     popover,
 };
 

--- a/crates/ui/src/stats.rs
+++ b/crates/ui/src/stats.rs
@@ -29,7 +29,7 @@ use theme::Theme;
 use web_time::Instant;
 
 use crate::{
-    material::{self, Frosted as _},
+    material::{self, Glass as _},
     popover,
 };
 

--- a/crates/ui/src/widgets/controls.rs
+++ b/crates/ui/src/widgets/controls.rs
@@ -208,7 +208,7 @@ pub trait Controls: ThemeExt {
             .rounded(px(Theme::button_radius()))
             .bg(theme.input_bg)
             .border_1()
-            .border_color(if open { theme.caret } else { theme.border })
+            .border_color(if open { theme.ring } else { theme.border })
             .text_size(px(13.0))
             .text_color(theme.text)
             .cursor_pointer()

--- a/crates/ui/src/widgets/layout.rs
+++ b/crates/ui/src/widgets/layout.rs
@@ -15,7 +15,18 @@ pub struct SplitDrag;
 
 /// Width of the divider's grab strip: the 1px line plus zed's own 4px of slack
 /// each side (`workspace::HANDLE_HITBOX_SIZE`) — a 1px target is unhittable.
-const SPLIT_HANDLE_HIT: f32 = 9.0;
+pub const SPLIT_HANDLE_HIT: f32 = 9.0;
+
+/// What a [`Layout::split_handle`] paints. `Ghost` is for a pane that already
+/// draws the edge itself; the strip still takes the drag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SplitStyle {
+    /// A hairline of its own, lit while grabbed.
+    Line {
+        dragging: bool,
+    },
+    Ghost,
+}
 
 pub trait Layout: ThemeExt {
     /// The disclosure chevron: right when collapsed, down when expanded.
@@ -138,27 +149,36 @@ pub trait Layout: ThemeExt {
     ///     }))
     ///     .child(div().w(relative(self.fraction)).child(left))
     ///     .child(
-    ///         theme.split_handle(Axis::Horizontal, self.dragging)
+    ///         theme.split_handle(Axis::Horizontal, SplitStyle::Line { dragging: self.dragging })
     ///             .id("split-handle")
     ///             .on_drag(SplitDrag, |_, _, _, cx| cx.new(|_| gpui::Empty)),
     ///     )
     ///     .child(div().flex_1().child(right))
     /// ```
-    fn split_handle(&self, axis: gpui::Axis, dragging: bool) -> Div {
+    fn split_handle(&self, axis: gpui::Axis, style: SplitStyle) -> Div {
         let theme = self.theme();
-        let line = if dragging { theme.caret } else { theme.border };
+        let line = match style {
+            SplitStyle::Line { dragging } => {
+                Some(if dragging { theme.caret } else { theme.border })
+            }
+            SplitStyle::Ghost => None,
+        };
         let handle = div().flex_none().flex().items_center().justify_center();
         match axis {
             gpui::Axis::Horizontal => handle
                 .w(px(SPLIT_HANDLE_HIT))
                 .h_full()
                 .cursor_col_resize()
-                .child(div().w(px(1.0)).h_full().bg(line)),
+                .when_some(line, |el, line| {
+                    el.child(div().w(px(1.0)).h_full().bg(line))
+                }),
             gpui::Axis::Vertical => handle
                 .h(px(SPLIT_HANDLE_HIT))
                 .w_full()
                 .cursor_row_resize()
-                .child(div().h(px(1.0)).w_full().bg(line)),
+                .when_some(line, |el, line| {
+                    el.child(div().h(px(1.0)).w_full().bg(line))
+                }),
         }
     }
 

--- a/crates/ui/src/widgets/mod.rs
+++ b/crates/ui/src/widgets/mod.rs
@@ -19,7 +19,7 @@ mod status;
 pub use buttons::{ButtonStyle, Buttons};
 pub use content::Content;
 pub use controls::{Controls, SliderDrag, slider_fraction};
-pub use layout::{Layout, SplitDrag};
+pub use layout::{Layout, SPLIT_HANDLE_HIT, SplitDrag, SplitStyle};
 pub use scaffolding::{OPTION_CARD_HEIGHT, OPTION_CARD_RADIUS, Scaffolding};
 pub use status::Status;
 

--- a/crates/ui/tests/frames.rs
+++ b/crates/ui/tests/frames.rs
@@ -23,7 +23,7 @@ use gpui::{
     Animation, AnimationExt, AnyElement, Context, IntoElement, ParentElement, Render, Styled,
     TestAppContext, Window, WindowHandle, div, px, size,
 };
-use motion::Painter;
+use motion::{AppExt as _, Painter};
 use theme::{Appearance, Theme};
 use ui::loaders;
 
@@ -104,7 +104,13 @@ impl Render for Counted {
 }
 
 fn open(cx: &mut TestAppContext, drive: Drive) -> (Rc<RefCell<usize>>, WindowHandle<Counted>) {
-    cx.update(|cx| Theme::install_custom(Theme::for_appearance(Appearance::Dark), cx));
+    cx.update(|cx| {
+        Theme::install_custom(Theme::for_appearance(Appearance::Dark), cx);
+        // A test window is never the platform's *active* window, and the
+        // library refuses claims for an app nobody is looking at. What these
+        // measure is what a foreground app costs, so say so.
+        cx.set_pause_when_inactive(false);
+    });
     let renders = Rc::new(RefCell::new(0));
     let window = cx.open_window(size(px(200.), px(200.)), {
         let renders = renders.clone();

--- a/www/docs/layout.md
+++ b/www/docs/layout.md
@@ -3,23 +3,25 @@ title: Layout
 description: Spacing steps, corner radii and chrome heights as plain numbers on Theme — no layout constant ever depends on which color is painted.
 ---
 
-Law 4: numbers drive layout, colors are paint. The layout constants are `f32` associated consts on `Theme`, so they resolve without reading the global at all:
+Law 4: numbers drive layout, colors are paint. Spacing and chrome heights are `f32` associated consts on `Theme` and the radii are `f32` functions, so a layout number resolves without reading the theme global at all:
 
 ```rust
 div()
     .gap(px(Theme::SPACE_SM))
-    .rounded(px(Theme::BUTTON_RADIUS))
+    .rounded(px(Theme::button_radius()))
     .h(px(Theme::HEADER_HEIGHT))
 ```
 
-Spacing is `SPACE_XS` 4, `SPACE_SM` 8, `SPACE_MD` 12, `SPACE_LG` 16. Radii run `CONTROL_RADIUS` 6 for things that sit inside a control, `BUTTON_RADIUS` 8 for controls themselves, `PANEL_RADIUS` 10 for cards, `SURFACE_RADIUS` 12 for floating surfaces, `BUBBLE_RADIUS` 16 for message bubbles. Chrome heights — `TITLEBAR_HEIGHT`, `HEADER_HEIGHT`, `STATUS_STRIP_HEIGHT` — are named for the same reason: a status strip that is reserved rather than conditional keeps the composer from shifting when it fills.
+Spacing is `SPACE_XS` 4, `SPACE_SM` 8, `SPACE_MD` 12, `SPACE_LG` 16.
 
-`SURFACE_RADIUS` is read at both ends of a glass surface: the border paints it, and `ui::material` cuts the backdrop blur to it. A blur cut to a different radius frosts square corners outside a round border, visible only on glass and only at the corners — which is why the number is named once instead of written twice.
+Radii are functions rather than consts, because every one of them is a ratio of `BASE_RADIUS` 8 and `Brand::radius` moves the whole set together. They run `control_radius()` 0.75x for things that sit inside a control, `button_radius()` 1x for controls themselves, `panel_radius()` 1.25x for cards, `surface_radius()` 1.5x for floating surfaces, `bubble_radius()` 2x for message bubbles. Chrome heights — `TITLEBAR_HEIGHT`, `HEADER_HEIGHT`, `STATUS_STRIP_HEIGHT` — are named for the same reason: a status strip that is reserved rather than conditional keeps the composer from shifting when it fills.
+
+`surface_radius()` is read at both ends of a glass surface: the border paints it, and `ui::material` cuts the backdrop blur to it. A blur cut to a different radius frosts square corners outside a round border, visible only on glass and only at the corners — which is why the number is named once instead of written twice.
 
 Nested corners come out of arithmetic rather than a second constant:
 
 ```rust
-Theme::inset_radius(Theme::SURFACE_RADIUS, 4.0) // 8.0
+Theme::inset_radius(Theme::surface_radius(), 4.0) // 8.0
 ```
 
 That is SwiftUI's `ContainerRelativeShape` rule. gpui has no container shape to inherit at paint time, so the relationship is stated where the child is defined — a container that changes its padding carries its rows with it, and the derived value never hardens into a constant of its own.

--- a/www/docs/material.md
+++ b/www/docs/material.md
@@ -1,17 +1,22 @@
 ---
 title: Materials
-description: The glass float — a backdrop-blurred card painted in one scene layer, with a nested-layer escape hatch for overlays inside it.
+description: Two backdrop surfaces — a frosted card that blurs what it covers, and liquid glass that refracts it at the rim.
 ---
 
-`material` wraps a floating card so its entire subtree paints inside one gpui scene layer, with the backdrop blur painted first, structurally under the content:
+Both surfaces come off the `Glass` trait, so any element carrying a corner radius has them. The radius is read from the element's own style, so the blur and the lens are cut to the corners the caller just asked for:
 
 ```rust
-use ui::material;
+use ui::material::{self, Glass as _};
 
-material::material(Theme::SURFACE_RADIUS, material::MENU_BLUR, card)
+card.rounded(px(Theme::surface_radius())).material(material::MENU_BLUR)
+card.rounded(px(Theme::surface_radius())).glass_effect()
 ```
 
-The corner radius must match the card's own rounding — the blur is cut to the radius you pass, and a mismatch frosts square corners outside a round border.
+`material::material(radius, blur, child)` is the free-function form, for a child that is not itself `Styled`.
+
+## Frost
+
+`material` wraps a floating card so its entire subtree paints inside one gpui scene layer, with the backdrop blur painted first, structurally under the content.
 
 One layer is the point. With per-primitive bounds-tree ordering a hover repaint elsewhere can reassign the card's quads relative to its siblings; inside a single layer the card's stacking is structural. The cost is that everything in the card shares one draw order, and equal orders render grouped by primitive kind — quads, then icons, then images — so a close button's circle painted "after" a thumbnail still lands under it. `material::layered` opens a nested layer to restore the intended stacking:
 
@@ -19,4 +24,36 @@ One layer is the point. With per-primitive bounds-tree ordering a hover repaint 
 material::layered(close_button)
 ```
 
-The blur needs `Window::paint_backdrop_blur` from bezel's gpui fork, and that is macOS Metal only. Elsewhere the primitive is ignored and the glass falls back to the theme's translucent tint over the OS window blur; on an opaque appearance `material` is a pass-through. Gate glass-only recipes on `theme.is_glass()`, never on the platform: the frost alpha is per-appearance, and light chrome is opaque by design.
+## Liquid glass
+
+> **macOS only.** The lens is a Metal primitive from bezel's gpui fork. Everywhere else — web, Linux, Windows — `glass_effect` falls back to the backdrop tint: the card and its shape, without the refraction at the rim. `material::lensed(&theme)` answers it at runtime.
+
+`glass_effect` paints the card as a refracting surface: a bevel at the rim that displaces what is behind it, a per-channel fringe across that displacement, and an additive lift over an interior that passes the backdrop straight through.
+
+The profile is measured off SwiftUI's `.glassEffect(.clear)` (2026-08). On a 460x120 capsule the ruler behind it is displaced over the outer 27pt and is exactly unperturbed below that — a bezel with a flat interior, which is the 0.225 share of the shape's smaller side that `Theme::glass_bevel` returns. The interior measures `1.042 * backdrop + 19/255` across five luminances, so `Theme::glass_clear` composites additively and brightens whatever sits behind it at every level.
+
+`glass_effect` clears the card's own `bg`, because the lens paints the fill. Painting both buries the lens, and a caller who has to remember that is a caller who will forget.
+
+Glass is clear by default, and two builders move it:
+
+```rust
+card.glass_effect().tint(theme.accent.opacity(0.3))
+card.glass_effect().blurred(material::MENU_BLUR)
+```
+
+`tint` stands in for `glass_clear`'s neutral lift instead of adding to it, so a heavy alpha reads as paint and a light one as glass. `blurred` frosts the backdrop under the lens, for a surface that has to carry dense content.
+
+The rim width and the displacement amplitude are process-wide, for the same reason the base radius is — the element builders that paint a lens have no `cx` in scope:
+
+```rust
+theme::set_glass_bevel(0.225); // share of the shape's smaller side
+theme::set_glass_magnify(0.34); // signed: negative inverts the lens
+```
+
+## Where it runs
+
+Both need `Window::paint_backdrop_blur` from bezel's gpui fork, which is macOS Metal only — any macOS version, since the lens is our own shader and not `NSGlassEffectView`.
+
+Off macOS the frost alpha is 1.0, so `theme.is_glass()` is false and neither surface composites. `material` becomes a pass-through and the caller's own fill shows through unchanged. `glass_effect` has moved the fill inside the lens, so where the lens cannot run it paints `Theme::glass_overlay` — the same tint a floating card carries over a blur, without the blur under it. The card keeps its shape and the page still shows through; what is lost is the refraction at the rim, not the surface. A `tint` is painted over that backing, so a glass control that carries colour still carries it.
+
+Gate glass-only recipes on `theme.is_glass()`, never on the platform: the frost alpha is per-appearance, and light chrome is opaque by design.

--- a/www/docs/motion-catalog.md
+++ b/www/docs/motion-catalog.md
@@ -37,4 +37,17 @@ const BREATHE: MotionSpec = MotionSpec::new(1800, motion::EASE_IN_OUT);
 let phase = motion::pulse_delta(&BREATHE, cx.entity_id(), cx);
 ```
 
-`set_speed(10.0)` stretches every timeline in the catalog, which is how a screenshot burst samples a 200ms tween frame by frame. Reduced motion is gpui's own flag: `with_animation` elements snap to their end state and schedule nothing, and `pulse_delta` returns a static 0.
+`set_speed(10.0)` stretches every timeline in the catalog, which is how a screenshot burst samples a 200ms tween frame by frame.
+
+The app-level settings hang off `App` itself, through `AppExt`:
+
+```rust
+use motion::AppExt as _;
+
+cx.set_reduced_motion(true);
+cx.set_pause_when_inactive(false);
+```
+
+Reduced motion is gpui's own flag: `with_animation` elements snap to their end state and schedule nothing, and `pulse_delta` returns a static 0.
+
+`pause_when_inactive` is on by default, and stops the clock while no window is active. Nothing above stops on its own — a spinner in a backgrounded window held 30fps and 22% of a core indefinitely (2026-08, debug build), against 2% with this on. The claim is refused rather than cancelled, so nothing has to resume it: the ones already held lapse, the loop runs out of work and parks, and the refresh gpui does on activation brings the renders that claim again. Turn it off for a window that must keep moving while something else has focus — a side panel, a floating HUD.

--- a/www/docs/split.md
+++ b/www/docs/split.md
@@ -4,7 +4,7 @@ description: A hairline divider in a grab strip — the caller owns the fraction
 ---
 
 ```rust
-use ui::widgets::{self, SplitDrag};
+use ui::widgets::{self, Layout as _, SplitDrag, SplitStyle};
 
 div()
     .id("split")
@@ -16,14 +16,17 @@ div()
     }))
     .child(div().w(relative(self.fraction)).child(left))
     .child(
-        widgets::split_handle(&theme, Axis::Horizontal, self.dragging)
+        theme
+            .split_handle(Axis::Horizontal, SplitStyle::Line { dragging: self.dragging })
             .id("split-handle")
             .on_drag(SplitDrag, |_, _, _, cx| cx.new(|_| gpui::Empty)),
     )
     .child(div().flex_1().child(right))
 ```
 
-The gesture stays with the caller because the fraction does. `split_handle` paints a 1px line centred in a grab strip — the line plus 4px of slack each side, the same hitbox zed uses, because a 1px target is unhittable — and lights while `dragging`.
+The gesture stays with the caller because the fraction does. `split_handle` centres its line in a grab strip — the line plus 4px of slack each side, the same hitbox zed uses, because a 1px target is unhittable — and lights while `dragging`. The strip's width is `widgets::SPLIT_HANDLE_HIT`, for a caller laying out around it.
+
+`SplitStyle::Ghost` takes the same drag and paints nothing, for a pane that already draws the edge itself. Two hairlines a pixel apart read as a seam rather than a divider.
 
 `axis_fraction`'s last argument is the dead zone: `0.15` here keeps either pane from being squeezed away, clamping the answer to `0.15..=0.85`. On a zero-extent container, the frame before layout has run, it returns the minimum rather than dividing by zero.
 

--- a/www/src/app.css
+++ b/www/src/app.css
@@ -126,6 +126,19 @@ pre code.hljs {
 	color: var(--text);
 }
 
+/* A platform caveat the reader has to see before they build on the API. The
+   left rule carries it, so it reads as an aside rather than a second heading. */
+blockquote {
+	margin: 20px 0;
+	padding: 2px 0 2px 16px;
+	border-left: 2px solid var(--line-strong);
+	color: var(--muted);
+}
+
+blockquote strong {
+	color: var(--text);
+}
+
 h1,
 h2,
 h3 {


### PR DESCRIPTION


https://github.com/user-attachments/assets/ba8a8946-edd9-4bc9-9fd2-a39fa249f495



## Liquid glass

`Glass::glass_effect()` paints a card as a refracting surface: a bevel at the rim that displaces the backdrop, a per-channel fringe across it, and an additive lift over a flat pass-through interior.

The profile is measured off SwiftUI's `.glassEffect(.clear)` rather than eyeballed. On a 460x120 capsule the ruler behind it is displaced over the outer 27pt and is exactly unperturbed below that — a bezel with a flat interior, not a lens across the whole body — which is where the 0.225 bevel share comes from. The interior veil measures `1.042 * backdrop + 19/255` over five luminances, so it brightens what sits behind it rather than dimming it.

**Breaking:** the `Frosted` trait is now `Glass`. `material()` is unchanged — `glass_effect()` is the new entry point beside it.

New theme surface: `Theme::glass_clear`, `glass_bevel`, `glass_magnify` and `glass_dispersion`, plus `layout::set_glass_bevel` and `set_glass_magnify` so the rim width and amplitude stay knobs rather than constants.

## The lens runs on the web now

It started macOS-only, because the backdrop-blur primitive was read by the Metal renderer alone — `gpui_wgpu` never looked at it, so on the web a glass card came out an opaque slab. That primitive is now implemented in the fork's wgpu renderer, and the workspace moves to `bezel-gpui` 0.3.6 to pick it up.

The renderer side is three commits on the fork: the primitive is consumed by rendering the frame offscreen only when a scene actually contains a blur (frames without glass go straight to the surface and allocate nothing), and the gaussian Metal gets from `MPSImageGaussianBlur` is rebuilt as fragment passes, since WebGL2 has no compute. Blurs at or below 16 device px run at full resolution; above that they take a reduced path, because the downsample would otherwise be most of the blur rather than a cheapening of it.

Verified on Metal, on WebGPU with the storage-buffer instance transport, and on WebGL2 with the texture transport — frost matches Metal at matched sigma.

Where the lens still cannot run, `glass_effect()` now degrades to `Theme::glass_overlay` instead of an opaque `surface_overlay`, so the card keeps its shape and the page still shows through; what is lost is the refraction, not the surface. A `tint` is painted over that backing, so a glass control that carries colour still carries it — it used to be dropped entirely.

## Also in here

- `motion::AppExt` adds `pause_when_inactive`, on by default. One spinner in a backgrounded window held 30fps and 22% of a core indefinitely against 2% with this on. The animation claim is refused rather than cancelled, so nothing has to resume it — gpui refreshes on activation and the next render takes the claim again.
- The gallery keeps the app awake while the frame meter is up, and shows the meter on the page that documents it. Its glass probe gained a monotonic blur slider — the control used to report a number it was not passing — and says so when the lens cannot run.
- The split handle skips its own divider; the focus ring gets its own hairline token.
- Docs: `material` documents both surfaces and the fallback; `layout` and `split` had examples naming APIs that no longer exist, and `motion` had no page for `AppExt`.
- Workspace version 0.1.2 → 0.1.3.

## Verification

`cargo clippy --workspace --all-targets` clean, `cargo nextest run --workspace` 325 passing, `cargo check -p web --target wasm32-unknown-unknown` clean, and the native gallery run on Metal.

The wasm check is worth calling out: `gpui_web`'s font `include_bytes!` escapes its crate directory and has shipped broken to crates.io before, which is why the root manifest once carried a `[patch.crates-io]`. 0.3.6 builds wasm straight from the registry, so no patch section is needed.

## Known gap

`ui::material::LENSED` is `cfg!(any(target_os = "macos", target_family = "wasm"))`. Since the primitive now lives in `gpui_wgpu`, Linux and Windows have the lens too and will still get the flat fallback painted over it. The honest value is `true`; it is left alone here because neither platform can be tested from this machine.