### PR TITLE
feat(editor): tab indents and zoom support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bezel"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bezel-agent",
  "bezel-gpui",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-agent"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-blocks"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-editor"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bezel-gpui",
  "bezel-markdown",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-icons"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bezel-gpui",
  "icondata_core",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-markdown"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-motion"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-syntax"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bezel-theme",
  "tree-sitter",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-terminal"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "alacritty_terminal",
  "bezel-gpui",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-theme"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bezel-gpui",
  "objc",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-ui"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bezel-gpui",
  "bezel-icons",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "gallery"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bezel-agent",
  "bezel-blocks",
@@ -2785,7 +2785,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bezel",
  "bezel-gpui",
@@ -4201,7 +4201,7 @@ dependencies = [
 
 [[package]]
 name = "parity"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bezel-gpui",
  "bezel-gpui-platform",
@@ -6888,7 +6888,7 @@ dependencies = [
 
 [[package]]
 name = "web"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bezel-gpui",
  "bezel-gpui-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 license = "MIT"
 authors = ["clearloop <tianyi.gc@gmail.com>"]
@@ -33,17 +33,17 @@ rust-version = "1.85"
 [workspace.dependencies]
 # The short names are taken on crates.io, so packages publish as `bezel-*`; the
 # key here and each crate's `[lib] name` are what the source imports.
-bezel = { path = "crates/bezel", version = "0.1.5" }
-agent = { package = "bezel-agent", path = "crates/agent", version = "0.1.5" }
-theme = { package = "bezel-theme", path = "crates/theme", version = "0.1.5" }
-motion = { package = "bezel-motion", path = "crates/motion", version = "0.1.5" }
-ui = { package = "bezel-ui", path = "crates/ui", version = "0.1.5" }
-icons = { package = "bezel-icons", path = "crates/icons", version = "0.1.5" }
-markdown = { package = "bezel-markdown", path = "crates/markdown", version = "0.1.5" }
-blocks = { package = "bezel-blocks", path = "crates/blocks", version = "0.1.5" }
-editor = { package = "bezel-editor", path = "crates/editor", version = "0.1.5" }
-syntax = { package = "bezel-syntax", path = "crates/syntax", version = "0.1.5" }
-terminal = { package = "bezel-terminal", path = "crates/terminal", version = "0.1.5" }
+bezel = { path = "crates/bezel", version = "0.1.7" }
+agent = { package = "bezel-agent", path = "crates/agent", version = "0.1.7" }
+theme = { package = "bezel-theme", path = "crates/theme", version = "0.1.7" }
+motion = { package = "bezel-motion", path = "crates/motion", version = "0.1.7" }
+ui = { package = "bezel-ui", path = "crates/ui", version = "0.1.7" }
+icons = { package = "bezel-icons", path = "crates/icons", version = "0.1.7" }
+markdown = { package = "bezel-markdown", path = "crates/markdown", version = "0.1.7" }
+blocks = { package = "bezel-blocks", path = "crates/blocks", version = "0.1.7" }
+editor = { package = "bezel-editor", path = "crates/editor", version = "0.1.7" }
+syntax = { package = "bezel-syntax", path = "crates/syntax", version = "0.1.7" }
+terminal = { package = "bezel-terminal", path = "crates/terminal", version = "0.1.7" }
 
 # crates-io
 libc = "0.2"

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -28,6 +28,7 @@ use crate::{
     layout::Layout,
     link::{self, Choice},
     slash::Slash,
+    text_size::{self, TextSize},
 };
 
 pub(crate) mod image;
@@ -37,11 +38,12 @@ pub(crate) mod menu;
 
 pub use keys::init;
 use keys::{
-    Backspace, Copy, Cut, Delete, DeleteToHome, DeleteWordLeft, DeleteWordRight, Dismiss, Down,
-    DuplicateBlock, End, Home, Indent, KillLine, Left, MoveBlockDown, MoveBlockUp, Outdent, Paste,
-    Redo, RemoveBlock, Right, SelectAll, SelectDown, SelectEnd, SelectHome, SelectLeft,
-    SelectRight, SelectUp, SelectWordLeft, SelectWordRight, SplitBlock, ToggleBold, ToggleCode,
-    ToggleItalic, ToggleStrike, Undo, Up, WordLeft, WordRight,
+    Backspace, Copy, Cut, DecreaseTextSize, Delete, DeleteToHome, DeleteWordLeft, DeleteWordRight,
+    Dismiss, Down, DuplicateBlock, End, Home, IncreaseTextSize, Indent, KillLine, Left,
+    MoveBlockDown, MoveBlockUp, Outdent, Paste, Redo, RemoveBlock, ResetTextSize, Right, SelectAll,
+    SelectDown, SelectEnd, SelectHome, SelectLeft, SelectRight, SelectUp, SelectWordLeft,
+    SelectWordRight, SplitBlock, ToggleBold, ToggleCode, ToggleItalic, ToggleStrike, Undo, Up,
+    WordLeft, WordRight,
 };
 
 const CONTEXT: &str = "BezelEditor";
@@ -60,7 +62,7 @@ fn key_context() -> KeyContext {
 /// An app holding comment threads has to hear that the document moved, or its
 /// side of the pairing goes stale against anchors that did not. Split the way
 /// [`ui::input::FieldEvent`] is, so a listener takes only the half it needs.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EditorEvent {
     /// The document is different, and the anchors have been mapped through it.
     Changed,
@@ -199,6 +201,13 @@ pub struct Editor {
     /// wrap belongs to two rows and answers with the first, so a caret that
     /// derived its own row would step down into the same one forever.
     goal: Option<gpui::Point<gpui::Pixels>>,
+    /// The size the app set this document in, in points, or `None` to follow
+    /// the app's own text size. Absolute rather than a factor over the ladder,
+    /// so moving the interface size leaves a document set to 16pt at 16pt.
+    ///
+    /// What the chords move is the shared adjustment on top of this; the base
+    /// itself is the app's alone.
+    text_size: Option<f32>,
 }
 
 impl Editor {
@@ -236,6 +245,7 @@ impl Editor {
             scroll: None,
             reveal: false,
             goal: None,
+            text_size: None,
         }
     }
 
@@ -246,6 +256,23 @@ impl Editor {
     pub fn with_undo_limit(mut self, limit: usize) -> Self {
         self.history = History::with_limit(limit);
         self
+    }
+
+    /// Open the document at a size of its own, in points — the app's settings
+    /// field for prose. Unset, it is set at the app's own text size.
+    ///
+    /// The base, not the current size: `cmd-+` moves a shared adjustment over
+    /// this, and `cmd-0` clears that adjustment to come back here.
+    pub fn with_text_size(mut self, points: f32) -> Self {
+        self.text_size = Some(points);
+        self
+    }
+
+    /// The base the app set, if any. Add
+    /// [`text_size_adjustment`](crate::text_size_adjustment) for what is on
+    /// screen.
+    pub fn text_size(&self) -> Option<f32> {
+        self.text_size
     }
 
     /// The box the document scrolls in, so typing off the bottom follows the
@@ -956,6 +983,30 @@ impl Editor {
         });
     }
 
+    fn increase_text_size(&mut self, _: &IncreaseTextSize, _: &mut Window, cx: &mut Context<Self>) {
+        self.step_text_size(TextSize::of(cx).step, cx);
+    }
+
+    fn decrease_text_size(&mut self, _: &DecreaseTextSize, _: &mut Window, cx: &mut Context<Self>) {
+        self.step_text_size(-TextSize::of(cx).step, cx);
+    }
+
+    fn reset_text_size(&mut self, _: &ResetTextSize, _: &mut Window, cx: &mut Context<Self>) {
+        text_size::reset_text_size(cx);
+    }
+
+    /// Sizing is not an edit: it changes nothing about the document, so it
+    /// leaves no undo step and no anchor moves.
+    ///
+    /// The step is taken against *this* document's size and stored back as the
+    /// shared adjustment, so a press at the end of the range banks up nothing
+    /// to work back through on the way down.
+    fn step_text_size(&mut self, by: f32, cx: &mut Context<Self>) {
+        let base = self.text_size.unwrap_or_else(theme::base_text_size);
+        let next = TextSize::of(cx).clamp(text_size::resolve(self.text_size, cx) + by);
+        text_size::set_adjustment(next - base, cx);
+    }
+
     /// Escape closes an open menu, and otherwise collapses a selection — the
     /// things there are to back out of, innermost first.
     fn dismiss(&mut self, _: &Dismiss, _: &mut Window, cx: &mut Context<Self>) {
@@ -1503,6 +1554,9 @@ impl Render for Editor {
             }))
             .on_action(cx.listener(Self::split_block))
             .on_action(cx.listener(Self::indent))
+            .on_action(cx.listener(Self::increase_text_size))
+            .on_action(cx.listener(Self::decrease_text_size))
+            .on_action(cx.listener(Self::reset_text_size))
             .on_action(cx.listener(Self::outdent))
             .on_action(cx.listener(Self::dismiss))
             .on_action(cx.listener(Self::select_all))
@@ -1621,6 +1675,12 @@ impl Render for Editor {
                             // painted — an editor that could hide it would be
                             // hiding a place you can already be typing.
                             caption: markdown::Caption::Shown,
+                            // The size is absolute, so the factor the ladder
+                            // is already scaled by comes back out of it —
+                            // otherwise the app's size and this one multiply.
+                            typography: Some(markdown::Typography::of(cx).scaled(
+                                text_size::resolve(self.text_size, cx) / theme::base_text_size(),
+                            )),
                         },
                         window,
                         cx,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12,7 +12,7 @@
 
 use gpui::{
     App, Context, CursorStyle, ElementInputHandler, EventEmitter, FocusHandle, Focusable,
-    MouseButton, Render, Styled as _, Task, Window, canvas, div, prelude::*,
+    KeyContext, MouseButton, Render, Styled as _, Task, Window, canvas, div, prelude::*,
 };
 use markdown::{
     Annotation, Block, BlockKind, BlockLayouts, Cursor, Doc, Form, Mark, Part, Selection, Splice,
@@ -45,6 +45,15 @@ use keys::{
 };
 
 const CONTEXT: &str = "BezelEditor";
+
+/// [`CONTEXT`], which every binding in [`keys`] is scoped to, plus the mark
+/// that keeps `tab` for [`Editor::indent`].
+fn key_context() -> KeyContext {
+    let mut context = KeyContext::default();
+    context.add(CONTEXT);
+    context.add(ui::focus::CLAIMS_TAB);
+    context
+}
 
 /// What the editor tells its host about.
 ///
@@ -1329,7 +1338,9 @@ impl Render for Editor {
             // what tells the gutter handle to stop pointing at a block the
             // pointer left behind.
             .id("bezel-editor")
-            .key_context(CONTEXT)
+            // The mark is what keeps `tab`: without it traversal answers the
+            // key first and the caret never sees it.
+            .key_context(key_context())
             .track_focus(&handle)
             // Tracking focus does not take it. Without this, clicking into the
             // document blurs the editor instead of putting a caret in it, and

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -192,6 +192,9 @@ pub struct Editor {
     /// owes it a reveal.
     scroll: Option<gpui::ScrollHandle>,
     reveal: bool,
+    /// Where the gutter handle was placed this frame, so the frame after can
+    /// tell whether the block moved out from under it.
+    handle_at: Option<gpui::Point<gpui::Pixels>>,
     /// The point vertical motion is trying to keep. Held across a run of
     /// up/down so walking through a short line and out the other side returns
     /// to the column you started in, and dropped by anything horizontal —
@@ -245,6 +248,7 @@ impl Editor {
             scroll: None,
             reveal: false,
             goal: None,
+            handle_at: None,
             text_size: None,
         }
     }
@@ -292,6 +296,28 @@ impl Editor {
     /// Read *after* paint, because a block that has only just appeared — the
     /// one Enter made — has no position recorded until it has painted once,
     /// which is exactly the case worth scrolling for.
+    /// Ask for another frame when the block the handle sits on has moved.
+    ///
+    /// The handle is built from the records of the frame *before* this one —
+    /// the document fills them as it paints, which is after the editor has
+    /// finished building its tree — so a block that has just been indented, or
+    /// grown a line, leaves the handle behind. Reading the records back here,
+    /// once the document has painted, is what turns that into one late frame
+    /// instead of a handle stranded until the caret blink happens to draw
+    /// again.
+    fn settle_handle(&mut self, window: &Window, cx: &mut Context<Self>) {
+        let focused = self.focus_handle.is_focused(window);
+        let now = self
+            .handle_block(focused)
+            .and_then(|ix| self.handle_origin(ix, cx));
+        if now != self.handle_at {
+            // Not `notify`: this runs *during* the draw, and the dirty flag it
+            // sets is cleared when that draw finishes. Asking for the next
+            // frame is what survives it.
+            window.request_animation_frame();
+        }
+    }
+
     fn reveal_caret(&mut self, cx: &mut Context<Self>) {
         if !self.reveal {
             return;
@@ -1691,8 +1717,11 @@ impl Render for Editor {
             .child(
                 canvas(|_, _, _| (), {
                     let entity = cx.entity();
-                    move |_, _, _, cx| {
-                        entity.update(cx, |this, cx| this.reveal_caret(cx));
+                    move |_, _, window, cx| {
+                        entity.update(cx, |this, cx| {
+                            this.reveal_caret(cx);
+                            this.settle_handle(window, cx);
+                        });
                     }
                 })
                 .absolute()

--- a/crates/editor/src/editor/keys.rs
+++ b/crates/editor/src/editor/keys.rs
@@ -52,6 +52,9 @@ actions!(
         RemoveBlock,
         ConfirmUrl,
         CancelUrl,
+        IncreaseTextSize,
+        DecreaseTextSize,
+        ResetTextSize,
     ]
 );
 
@@ -115,6 +118,14 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("cmd-i", ToggleItalic, ctx),
         KeyBinding::new("cmd-e", ToggleCode, ctx),
         KeyBinding::new("cmd-shift-x", ToggleStrike, ctx),
+        // Three chords for one key: `cmd-+` is `cmd-shift-=` on the keyboards
+        // that have no `+` of their own, and which of the two a platform
+        // reports is not ours to guess.
+        KeyBinding::new("cmd-=", IncreaseTextSize, ctx),
+        KeyBinding::new("cmd-+", IncreaseTextSize, ctx),
+        KeyBinding::new("cmd-shift-=", IncreaseTextSize, ctx),
+        KeyBinding::new("cmd--", DecreaseTextSize, ctx),
+        KeyBinding::new("cmd-0", ResetTextSize, ctx),
         // cmd = line, option = word: the macOS convention.
         KeyBinding::new("cmd-left", Home, ctx),
         KeyBinding::new("cmd-right", End, ctx),
@@ -153,6 +164,11 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("ctrl-i", ToggleItalic, ctx),
         KeyBinding::new("ctrl-e", ToggleCode, ctx),
         KeyBinding::new("ctrl-shift-x", ToggleStrike, ctx),
+        KeyBinding::new("ctrl-=", IncreaseTextSize, ctx),
+        KeyBinding::new("ctrl-+", IncreaseTextSize, ctx),
+        KeyBinding::new("ctrl-shift-=", IncreaseTextSize, ctx),
+        KeyBinding::new("ctrl--", DecreaseTextSize, ctx),
+        KeyBinding::new("ctrl-0", ResetTextSize, ctx),
         // ctrl = word on Windows/Linux, where there is no line modifier.
         KeyBinding::new("ctrl-left", WordLeft, ctx),
         KeyBinding::new("ctrl-right", WordRight, ctx),

--- a/crates/editor/src/editor/menu.rs
+++ b/crates/editor/src/editor/menu.rs
@@ -4,7 +4,10 @@
 //! All four are placed from positions `markdown::BlockLayouts` recorded as it
 //! painted, so none of them can drift from the text it points at.
 
-use gpui::{AnyElement, Context, CursorStyle, MouseButton, SharedString, div, prelude::*, px};
+use gpui::{
+    AnyElement, App, Context, CursorStyle, MouseButton, Pixels, Point, SharedString, div,
+    prelude::*, px,
+};
 use markdown::BlockKind;
 use motion::{Fade, Painter};
 use theme::{TextStyle, Theme, Typeset};
@@ -24,6 +27,32 @@ pub const SLASH_MENU: &str = "slash-menu";
 pub const BLOCK_HANDLE: &str = "block-handle";
 
 impl Editor {
+    /// The block the handle belongs on: the one being dragged, else the one
+    /// under the pointer, else the one the caret is in.
+    pub(super) fn handle_block(&self, focused: bool) -> Option<usize> {
+        self.lifted
+            .map(|(from, _)| from)
+            .or(self.hovered)
+            .or_else(|| focused.then(|| self.cursor().block))
+    }
+
+    /// Where the handle sits for that block, in this editor's own space.
+    ///
+    /// Centred on the block's first row, not dropped at the top of its box. A
+    /// block with nothing painted in it has no row to centre on and keeps the
+    /// box's top.
+    pub(super) fn handle_origin(&self, ix: usize, cx: &App) -> Option<Point<Pixels>> {
+        let bounds = self.layouts.block_bounds(ix)?;
+        let top = match self.layouts.first_row(ix) {
+            Some((row, line)) => row + (line - px(HANDLE_SIZE)) / 2.0,
+            None => bounds.origin.y,
+        };
+        Some(gpui::point(
+            bounds.origin.x - self.origin.x - px(Layout::of(cx).text_inset),
+            top - self.origin.y,
+        ))
+    }
+
     /// The gutter handle, on the block being dragged, else the one under the
     /// pointer, else the one the caret is in.
     ///
@@ -33,31 +62,26 @@ impl Editor {
     /// is the more immediate intent — and it comes at all because reaching a
     /// block by keyboard should not mean reaching for the mouse to act on it.
     pub(super) fn handle(
-        &self,
+        &mut self,
         focused: bool,
         theme: &Theme,
         cx: &mut Context<Self>,
     ) -> Option<AnyElement> {
-        let ix = self
-            .lifted
-            .map(|(from, _)| from)
-            .or(self.hovered)
-            .or_else(|| focused.then(|| self.cursor().block))?;
-        let bounds = self.layouts.block_bounds(ix)?;
-        // Centred on the block's first row, not dropped at the top of its box.
-        // A block with nothing painted in it has no row to centre on and keeps
-        // the box's top.
-        let top = match self.layouts.first_row(ix) {
-            Some((row, line)) => row + (line - px(HANDLE_SIZE)) / 2.0,
-            None => bounds.origin.y,
-        };
+        let placed = self
+            .handle_block(focused)
+            .and_then(|ix| Some((ix, self.handle_origin(ix, cx)?)));
+        // Kept even when there is none, so [`Self::settle_handle`] compares
+        // like with like and does not ask for a frame over a handle that is
+        // not there.
+        self.handle_at = placed.map(|(_, at)| at);
+        let (ix, at) = placed?;
         Some(
             div()
                 .id(BLOCK_HANDLE)
                 .debug_selector(|| BLOCK_HANDLE.to_string())
                 .absolute()
-                .left(bounds.origin.x - self.origin.x - px(Layout::of(cx).text_inset))
-                .top(top - self.origin.y)
+                .left(at.x)
+                .top(at.y)
                 .w(px(HANDLE_SIZE))
                 .h(px(HANDLE_SIZE))
                 .flex()

--- a/crates/editor/src/lib.rs
+++ b/crates/editor/src/lib.rs
@@ -15,6 +15,7 @@ mod history;
 mod layout;
 mod link;
 mod slash;
+mod text_size;
 
 pub use comment::{Anchor, CommentId};
 #[doc(hidden)]
@@ -26,3 +27,6 @@ pub use editor::{
 };
 pub use history::{DEFAULT_UNDO_LIMIT, EditKind, History, Step};
 pub use layout::{Layout, set_layout};
+pub use text_size::{
+    TextSize, adjust_text_size, reset_text_size, set_text_size, text_size_adjustment,
+};

--- a/crates/editor/src/text_size.rs
+++ b/crates/editor/src/text_size.rs
@@ -1,0 +1,102 @@
+//! How big a document is set, and the chords that nudge it.
+//!
+//! Two numbers, the way Xcode and Zed split them. The *base* is the app's, in
+//! points: a settings field, handed to [`Editor::with_text_size`], and never
+//! touched from in here. The *adjustment* is the reader's — what `cmd-+` moves,
+//! shared by every open document, and held in memory only. A reset clears the
+//! adjustment, and the base is what is left.
+//!
+//! Nothing here is persisted: storage is the app's, not a component library's.
+//! The base comes from whatever settings the app keeps, and an app that wants
+//! the adjustment to outlive the process stores [`text_size_adjustment`]
+//! beside it — beside, not folded into the base, or a reset has nowhere left
+//! to return to.
+//!
+//! [`Editor::with_text_size`]: crate::Editor::with_text_size
+
+use gpui::{App, Global};
+
+use theme::TextStyle;
+
+/// How far the chords move a document, in points — the unit a settings field
+/// is written in, so the two never need converting between.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TextSize {
+    /// Points per press. Whole points by default, so every stop is a size that
+    /// could be written into a settings file.
+    pub step: f32,
+    pub min: f32,
+    pub max: f32,
+}
+
+impl TextSize {
+    /// How the editor sizes, or [`TextSize::default`] before anything is
+    /// installed. Mirrors [`theme::Theme::of`].
+    pub fn of(cx: &App) -> Self {
+        cx.try_global::<Installed>()
+            .map_or_else(Self::default, |installed| installed.0)
+    }
+
+    /// A size brought inside the range, and rounded to a tenth of a point so a
+    /// run of steps lands on the same numbers each time.
+    pub(crate) fn clamp(self, points: f32) -> f32 {
+        (points.clamp(self.min, self.max) * 10.0).round() / 10.0
+    }
+}
+
+impl Default for TextSize {
+    /// A point per press, over the range the ladder itself stays legible in —
+    /// its smallest measured role at the bottom, twice the body at the top.
+    fn default() -> Self {
+        Self {
+            step: 1.0,
+            min: TextStyle::Caption2.size(),
+            max: TextStyle::Body.size() * 2.0,
+        }
+    }
+}
+
+struct Installed(TextSize);
+
+impl Global for Installed {}
+
+/// `editor::set_text_size(cx, my_steps)` — call once at boot.
+pub fn set_text_size(cx: &mut App, text_size: TextSize) {
+    cx.set_global(Installed(text_size));
+}
+
+/// What every document is currently set away from its base by, in points.
+///
+/// Zero unless a reader has reached for the chords. A host showing the size in
+/// a status bar reads this; one that does not care never has to know it exists.
+pub fn text_size_adjustment(cx: &App) -> f32 {
+    cx.try_global::<Adjustment>().map_or(0.0, |held| held.0)
+}
+
+/// Move every open document by `points`, each staying inside the range against
+/// its own base.
+pub fn adjust_text_size(cx: &mut App, points: f32) {
+    set_adjustment(text_size_adjustment(cx) + points, cx);
+}
+
+/// Give every document back to the size its app set it at.
+pub fn reset_text_size(cx: &mut App) {
+    set_adjustment(0.0, cx);
+}
+
+pub(crate) fn set_adjustment(points: f32, cx: &mut App) {
+    cx.set_global(Adjustment(points));
+    // The adjustment is shared, so this is what moves the documents in every
+    // other window with it.
+    cx.refresh_windows();
+}
+
+/// The size a document with this base is actually set at.
+pub(crate) fn resolve(base: Option<f32>, cx: &App) -> f32 {
+    let base = base.unwrap_or_else(theme::base_text_size);
+    TextSize::of(cx).clamp(base + text_size_adjustment(cx))
+}
+
+struct Adjustment(f32);
+
+impl Global for Adjustment {}

--- a/crates/editor/tests/interaction.rs
+++ b/crates/editor/tests/interaction.rs
@@ -329,6 +329,40 @@ fn the_handle_follows_the_caret(cx: &mut TestAppContext) {
     );
 }
 
+/// The bug (#14): the block's box was recorded outside its indent padding, so
+/// every level answered with the same left edge and the handle stayed at the
+/// margin while the block it belongs to moved right. And because the handle is
+/// built from the frame before's records, the frame that would put it right
+/// was only ever the *next* one somebody else asked for — the caret blink,
+/// half a second later.
+#[gpui::test]
+fn the_handle_moves_in_with_an_indented_block(cx: &mut TestAppContext) {
+    let (editor, _window, mut cx) = open_with("- first\n- second", &mut *cx);
+    go_to_block(&editor, &mut cx, 1);
+    cx.run_until_parked();
+    let before = cx
+        .debug_bounds(editor::BLOCK_HANDLE)
+        .expect("a handle")
+        .origin;
+
+    cx.simulate_keystrokes("tab");
+    // The frame the editor asks for once it sees the block has moved out from
+    // under the handle. A running app draws it; a test has to say so.
+    cx.update(|window, cx| window.simulate_next_frame(cx));
+    cx.run_until_parked();
+
+    let after = cx
+        .debug_bounds(editor::BLOCK_HANDLE)
+        .expect("still a handle")
+        .origin;
+    assert_eq!(
+        after.x - before.x,
+        px(22.0),
+        "the handle followed the block in by one indent"
+    );
+    assert_eq!(after.y, before.y, "and stayed on the same row");
+}
+
 /// The bug: backspace at the start of an empty block steps the caret into the
 /// previous block's last part — right while the block still holds text, and a
 /// trap once it does not. Nothing above an atomic block merges, so the empty

--- a/crates/editor/tests/interaction.rs
+++ b/crates/editor/tests/interaction.rs
@@ -256,6 +256,59 @@ fn tab_indents_a_list_item_and_shift_tab_puts_it_back(cx: &mut TestAppContext) {
     );
 }
 
+/// The bug (#14): `tab` is bound twice — `Indent` here, `FocusNext` in
+/// [`ui::focus`] with no context and so at the same depth — and the tie went to
+/// whichever crate was initialised last. In the gallery that was `focus`, so
+/// `tab` moved focus and a list could not be nested at all.
+#[gpui::test]
+fn tab_indents_with_focus_traversal_installed(cx: &mut TestAppContext) {
+    use gpui::{Context, IntoElement, Render, Window, div, prelude::*};
+
+    /// A host that traverses on `tab`, as an app's root view does.
+    struct Host(Entity<Editor>);
+
+    impl Render for Host {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            ui::focus::traversal(div())
+                .size_full()
+                .child(self.0.clone())
+        }
+    }
+
+    cx.update(|cx| {
+        theme::Theme::install(theme::Appearance::Dark, cx);
+        editor::init(cx);
+        // The order `apps/gallery` installs them in: `focus` binds `tab` last.
+        ui::focus::init(cx);
+    });
+    let window = cx.add_window(|_, cx| Host(cx.new(|cx| Editor::new(SOURCE, cx))));
+    let editor = cx.update(|cx| window.root(cx).unwrap().read(cx).0.clone());
+    let mut cx = VisualTestContext::from_window(window.into(), cx);
+    cx.simulate_resize(size(px(360.0), px(600.0)));
+    cx.update(|window, cx| {
+        let handle = editor.read(cx).focus_handle(cx);
+        window.focus(&handle, cx);
+    });
+    cx.run_until_parked();
+
+    go_to_block(&editor, &mut cx, 3);
+    cx.simulate_keystrokes("tab");
+    assert!(
+        source(&editor, &mut cx).contains("- first\n    - second"),
+        "tab nests the item rather than moving focus: {:?}",
+        source(&editor, &mut cx)
+    );
+    cx.simulate_keystrokes("shift-tab");
+    assert!(
+        source(&editor, &mut cx).contains("- first\n- second"),
+        "and shift-tab lifts it back rather than stepping the other way"
+    );
+    assert!(
+        cx.update(|window, cx| editor.read(cx).focus_handle(cx).is_focused(window)),
+        "the document still holds focus"
+    );
+}
+
 /// The handle used to follow the pointer and nothing else, so a document being
 /// worked in by keyboard had no handle at all until you reached for the mouse.
 #[gpui::test]

--- a/crates/editor/tests/text_size.rs
+++ b/crates/editor/tests/text_size.rs
@@ -1,0 +1,187 @@
+//! `cmd-+`/`cmd--` over a drawn document: what the chords move, and how far.
+//!
+//! Xcode's and Zed's split — the app owns a base size, the reader owns an
+//! adjustment over it, and a reset clears the adjustment.
+
+use editor::{Editor, TextSize};
+use gpui::{
+    AppContext as _, Entity, Focusable, Pixels, TestAppContext, VisualTestContext, px, size,
+};
+
+#[cfg(target_os = "macos")]
+const PRIMARY: &str = "cmd";
+#[cfg(not(target_os = "macos"))]
+const PRIMARY: &str = "ctrl";
+
+const SOURCE: &str = "# Title\n\nA paragraph.";
+
+fn open(cx: &mut TestAppContext) -> (Entity<Editor>, VisualTestContext) {
+    open_at(None, None, cx)
+}
+
+fn open_at(
+    sizing: Option<TextSize>,
+    base: Option<f32>,
+    cx: &mut TestAppContext,
+) -> (Entity<Editor>, VisualTestContext) {
+    cx.update(|cx| {
+        theme::Theme::install(theme::Appearance::Dark, cx);
+        editor::init(cx);
+        if let Some(sizing) = sizing {
+            editor::set_text_size(cx, sizing);
+        }
+    });
+    let window = cx.add_window(|_, cx| {
+        let editor = Editor::new(SOURCE, cx);
+        match base {
+            Some(points) => editor.with_text_size(points),
+            None => editor,
+        }
+    });
+    let editor = window.root(cx).unwrap();
+    let mut visual = VisualTestContext::from_window(window.into(), cx);
+    visual.simulate_resize(size(px(360.0), px(600.0)));
+    visual.update(|window, cx| {
+        let handle = editor.read(cx).focus_handle(cx);
+        window.focus(&handle, cx);
+    });
+    visual.run_until_parked();
+    (editor, visual)
+}
+
+/// The line box the title actually painted in — proof the size reached the
+/// glyphs rather than only the number it is held in. A collapsed caret has no
+/// bounds, so this selects a character to ask about.
+fn painted(editor: &Entity<Editor>, cx: &mut VisualTestContext) -> Pixels {
+    cx.simulate_keystrokes("shift-right");
+    cx.run_until_parked();
+    cx.update(|_, cx| {
+        editor
+            .read(cx)
+            .selection_bounds()
+            .expect("the selected row painted")
+            .size
+            .height
+    })
+}
+
+fn adjustment(cx: &mut VisualTestContext) -> f32 {
+    cx.update(|_, cx| editor::text_size_adjustment(cx))
+}
+
+#[gpui::test]
+fn a_press_steps_the_size_by_a_point(cx: &mut TestAppContext) {
+    let (editor, mut cx) = open(cx);
+    let before = painted(&editor, &mut cx);
+    cx.simulate_keystrokes(&format!("{PRIMARY}-="));
+    cx.run_until_parked();
+    assert_eq!(adjustment(&mut cx), 1.0);
+    assert!(
+        painted(&editor, &mut cx) > before,
+        "and the text painted larger with it"
+    );
+}
+
+/// The base is the app's and the chords never touch it — a reset has somewhere
+/// to come back to precisely because the adjustment is the only thing that moved.
+#[gpui::test]
+fn the_chords_leave_the_apps_base_alone(cx: &mut TestAppContext) {
+    let (editor, mut cx) = open_at(None, Some(16.0), cx);
+    let before = painted(&editor, &mut cx);
+    cx.simulate_keystrokes(&format!("{PRIMARY}-= {PRIMARY}-="));
+    cx.run_until_parked();
+    assert_eq!(adjustment(&mut cx), 2.0);
+    assert_eq!(
+        cx.update(|_, cx| editor.read(cx).text_size()),
+        Some(16.0),
+        "the settings size is untouched"
+    );
+    cx.simulate_keystrokes(&format!("{PRIMARY}-0"));
+    cx.run_until_parked();
+    assert_eq!(adjustment(&mut cx), 0.0);
+    assert_eq!(
+        painted(&editor, &mut cx),
+        before,
+        "and a reset is back at the base exactly"
+    );
+}
+
+/// The adjustment is shared, so every open document moves together — Zed moves
+/// every buffer, not the focused one.
+#[gpui::test]
+fn every_open_document_moves_together(cx: &mut TestAppContext) {
+    let (focused, mut cx) = open_at(None, Some(16.0), cx);
+    let other = cx.update(|_, cx| cx.new(|cx| Editor::new(SOURCE, cx).with_text_size(11.0)));
+    cx.simulate_keystrokes(&format!("{PRIMARY}-="));
+    cx.run_until_parked();
+    assert_eq!(adjustment(&mut cx), 1.0, "one adjustment, for both of them");
+    assert_eq!(
+        cx.update(|_, cx| (focused.read(cx).text_size(), other.read(cx).text_size())),
+        (Some(16.0), Some(11.0)),
+        "each keeps the base its app set, and rides the same step over it"
+    );
+}
+
+/// The whole reason the base is in points: an app with its own size for prose
+/// sets it once, and moving the *interface* size must not multiply into it.
+#[gpui::test]
+fn a_base_in_points_ignores_the_apps_interface_size(cx: &mut TestAppContext) {
+    let (editor, mut cx) = open_at(None, Some(20.0), cx);
+    let before = painted(&editor, &mut cx);
+    cx.update(|_, cx| theme::set_base_text_size(18.0, cx));
+    cx.run_until_parked();
+    assert_eq!(
+        painted(&editor, &mut cx),
+        before,
+        "the article stayed at 20pt while the interface grew around it"
+    );
+}
+
+/// A press at the ceiling banks up nothing, so one press back down is one step
+/// down rather than the first of however many were swallowed.
+#[gpui::test]
+fn the_range_holds_at_both_ends(cx: &mut TestAppContext) {
+    let sizing = TextSize {
+        min: 12.0,
+        max: 16.0,
+        step: 1.0,
+    };
+    let (editor, mut cx) = open_at(Some(sizing), Some(13.0), cx);
+    for _ in 0..20 {
+        cx.simulate_keystrokes(&format!("{PRIMARY}-="));
+    }
+    cx.run_until_parked();
+    assert_eq!(adjustment(&mut cx), 3.0, "13pt stopped at the 16pt ceiling");
+    let ceiling = painted(&editor, &mut cx);
+    cx.simulate_keystrokes(&format!("{PRIMARY}--"));
+    cx.run_until_parked();
+    assert_eq!(adjustment(&mut cx), 2.0);
+    assert!(
+        painted(&editor, &mut cx) < ceiling,
+        "one press down is one step down"
+    );
+    for _ in 0..20 {
+        cx.simulate_keystrokes(&format!("{PRIMARY}--"));
+    }
+    cx.run_until_parked();
+    assert_eq!(adjustment(&mut cx), -1.0, "and it stops at the floor");
+}
+
+/// A host that wants the adjustment to outlive the process can read it and put
+/// it back, without the library having anywhere to write it.
+#[gpui::test]
+fn a_host_can_read_the_adjustment_and_put_it_back(cx: &mut TestAppContext) {
+    let (editor, mut cx) = open_at(None, Some(16.0), cx);
+    cx.simulate_keystrokes(&format!("{PRIMARY}-= {PRIMARY}-="));
+    cx.run_until_parked();
+    let stored = adjustment(&mut cx);
+    let painted_at = painted(&editor, &mut cx);
+
+    cx.update(|_, cx| editor::reset_text_size(cx));
+    cx.run_until_parked();
+    assert_ne!(painted(&editor, &mut cx), painted_at);
+
+    cx.update(|_, cx| editor::adjust_text_size(cx, stored));
+    cx.run_until_parked();
+    assert_eq!(painted(&editor, &mut cx), painted_at, "restored");
+}

--- a/crates/markdown/src/edit.rs
+++ b/crates/markdown/src/edit.rs
@@ -1034,8 +1034,30 @@ impl Doc {
             return false;
         }
         self.shift_subtree(ix, 1);
+        // A run that has just been nested has nothing above it to carry on
+        // from, so it starts over. `renumber` cannot decide this on its own: a
+        // list written `5.` keeps its 5, and from the numbers alone the two
+        // cases look the same.
+        if self.begins_run(ix)
+            && let BlockKind::Ordered { number, .. } = &mut self.blocks[ix].kind
+        {
+            *number = 1;
+        }
         self.repair();
         true
+    }
+
+    /// Whether the block at `ix` starts a run of ordered items rather than
+    /// carrying one on: the nearest block at its own indent, before the list
+    /// it sits in ends, is not an ordered item.
+    fn begins_run(&self, ix: usize) -> bool {
+        let indent = self.blocks[ix].indent;
+        self.blocks[..ix]
+            .iter()
+            .rev()
+            .take_while(|block| block.indent >= indent)
+            .find(|block| block.indent == indent)
+            .is_none_or(|block| !matches!(block.kind, BlockKind::Ordered { .. }))
     }
 
     /// How deep block `ix` is allowed to sit.

--- a/crates/markdown/src/render.rs
+++ b/crates/markdown/src/render.rs
@@ -605,25 +605,35 @@ pub fn render_with(doc: &Doc, editing: Editing, window: &mut Window, cx: &mut Ap
             .size_full()
         });
         column = column.child(
+            // The indent sits on the outside and the recorder on the inside,
+            // so what is recorded is the box the block's text actually
+            // occupies. Recorded outside the padding, every level answered
+            // with the same left edge, and a gutter handle placed from it
+            // stayed at the margin while the block it belongs to moved right.
             div()
                 .mt(px(gap))
                 .pl(px(block.indent as f32 * INDENT_WIDTH))
-                .relative()
-                .children(frame)
-                // What a caret cannot enter still has to show it is inside the
-                // selection, or a rule between two paragraphs looks untouched
-                // right up until it disappears.
-                .when(overlay.covers_block() && block.opaque(), |el| {
-                    el.rounded(px(4.0)).bg(theme.selection)
-                })
-                .child(block_element(
-                    block,
-                    overlay,
-                    &typography,
-                    &theme,
-                    window,
-                    cx,
-                )),
+                .child(
+                    div()
+                        .w_full()
+                        .relative()
+                        .children(frame)
+                        // What a caret cannot enter still has to show it is
+                        // inside the selection, or a rule between two
+                        // paragraphs looks untouched right up until it
+                        // disappears.
+                        .when(overlay.covers_block() && block.opaque(), |el| {
+                            el.rounded(px(4.0)).bg(theme.selection)
+                        })
+                        .child(block_element(
+                            block,
+                            overlay,
+                            &typography,
+                            &theme,
+                            window,
+                            cx,
+                        )),
+                ),
         );
     }
 

--- a/crates/markdown/src/render.rs
+++ b/crates/markdown/src/render.rs
@@ -148,6 +148,10 @@ pub struct Editing<'a> {
     /// Shown on the caret's block while it holds nothing.
     pub placeholder: Option<SharedString>,
     pub caption: Caption,
+    /// What to set the document in. `None` takes the installed
+    /// [`Typography`] — a caller sizing one document apart from the rest
+    /// passes [`Typography::scaled`].
+    pub typography: Option<Typography>,
 }
 
 impl Default for Editing<'_> {
@@ -161,6 +165,7 @@ impl Default for Editing<'_> {
             annotations: &[],
             placeholder: None,
             caption: Caption::default(),
+            typography: None,
         }
     }
 }
@@ -553,6 +558,7 @@ pub fn render_with(doc: &Doc, editing: Editing, window: &mut Window, cx: &mut Ap
         annotations,
         placeholder,
         caption,
+        typography,
     } = editing;
     // Refilled every frame, in paint order — and emptied in *prepaint*, not
     // here. An editor reads last frame's positions while building this frame's
@@ -568,7 +574,7 @@ pub fn render_with(doc: &Doc, editing: Editing, window: &mut Window, cx: &mut Ap
     // Cloned once so the theme is readable while `cx` stays free for the
     // element state the copy button needs.
     let theme = Theme::of(cx).clone();
-    let typography = Typography::of(cx);
+    let typography = typography.unwrap_or_else(|| Typography::of(cx));
     let mut column = div().flex().flex_col().children(reset);
 
     for (ix, block) in doc.blocks.iter().enumerate() {

--- a/crates/markdown/src/typography.rs
+++ b/crates/markdown/src/typography.rs
@@ -32,6 +32,21 @@ impl Typography {
             .map_or_else(Self::default, |installed| installed.0)
     }
 
+    /// The same set at `scale` times the ladder — what a zoomed document is
+    /// painted with. Every role moves together, so the ratios hold.
+    pub fn scaled(self, scale: f32) -> Self {
+        Self {
+            body: self.body.scaled(scale),
+            h1: self.h1.scaled(scale),
+            h2: self.h2.scaled(scale),
+            h3: self.h3.scaled(scale),
+            h4: self.h4.scaled(scale),
+            code: self.code.scaled(scale),
+            card: self.card.scaled(scale),
+            caption: self.caption.scaled(scale),
+        }
+    }
+
     pub fn heading(&self, level: u8) -> Metrics {
         match level {
             1 => self.h1,

--- a/crates/markdown/tests/edit.rs
+++ b/crates/markdown/tests/edit.rs
@@ -125,6 +125,38 @@ fn indenting_carries_the_children() {
     assert_eq!(doc.blocks[2].indent, 2, "the child came along");
 }
 
+/// The bug: a nested run carried on from the number the item had at the level
+/// it left, so tabbing the second item of a list gave a sub-list starting at 2.
+#[test]
+fn a_nested_run_starts_over() {
+    let mut doc = parse("1. a\n2. b\n3. c");
+    assert!(doc.indent(1));
+    assert_eq!(
+        serialize(&doc),
+        "1. a\n    1. b\n2. c",
+        "the sub-list starts at 1, and the outer list closes up behind it"
+    );
+    assert!(doc.indent(2));
+    assert_eq!(
+        serialize(&doc),
+        "1. a\n    1. b\n    2. c",
+        "the next item into the same sub-list carries it on"
+    );
+}
+
+/// Starting over is the *edit's* doing, not the numbering's: markdown honours
+/// the first number of a list, so a document written from 5 is still read from
+/// 5. Nesting one is what makes a new list, and a new list starts at 1.
+#[test]
+fn parsing_leaves_a_run_that_names_its_own_start() {
+    assert_eq!(serialize(&parse("5. a\n6. b")), "5. a\n6. b");
+    let mut doc = parse("- x\n5. a\n6. b");
+    assert!(doc.indent(1));
+    // `b` is left starting the outer run, and a run keeps the number it
+    // names — the same rule, now applying to it.
+    assert_eq!(serialize(&doc), "- x\n    1. a\n6. b");
+}
+
 #[test]
 fn a_block_cannot_indent_more_than_one_past_the_one_above() {
     let mut doc = parse("- a\n- b");

--- a/crates/theme/src/theme/typography.rs
+++ b/crates/theme/src/theme/typography.rs
@@ -115,6 +115,9 @@ pub struct Metrics {
     /// The ladder carries one bold cell, so a set needing several heading
     /// weights names its own here rather than reading it off the role.
     pub weight: FontWeight,
+    /// A factor over the painted ladder, for one surface sized apart from the
+    /// rest — a document the reader has zoomed. 1.0 is the ladder itself.
+    pub scale: f32,
 }
 
 impl Metrics {
@@ -123,11 +126,18 @@ impl Metrics {
             role,
             leading,
             weight,
+            scale: 1.0,
         }
     }
 
+    /// The same metrics at `scale` times the ladder. Replaces rather than
+    /// compounds, so a slider handing over an absolute factor cannot drift.
+    pub const fn scaled(self, scale: f32) -> Self {
+        Self { scale, ..self }
+    }
+
     pub fn size(self) -> f32 {
-        self.role.painted()
+        self.role.painted() * self.scale
     }
 
     pub fn line_height(self) -> f32 {

--- a/crates/ui/src/focus.rs
+++ b/crates/ui/src/focus.rs
@@ -48,6 +48,22 @@ actions!(
 /// so it wins `enter` while focused and gives it straight back afterwards.
 pub const CONTROL_KEY_CONTEXT: &str = "Control";
 
+/// Added to a surface's key context when `tab` is its own key — a document
+/// nests a list with it. [`traversal`] stands down while that surface holds
+/// focus.
+///
+/// A mark, not a predicate on the binding: any predicate fails against an empty
+/// context stack, which is what an element with no key context dispatches
+/// against.
+///
+/// ```ignore
+/// let mut context = KeyContext::default();
+/// context.add(MY_CONTEXT);
+/// context.add(focus::CLAIMS_TAB);
+/// div().key_context(context).track_focus(&self.focus_handle)
+/// ```
+pub const CLAIMS_TAB: &str = "ClaimsTab";
+
 /// Bind `tab` and `shift-tab`. Call once at startup.
 ///
 /// Optional, like [`crate::input::init`] — the actions are public, so an app
@@ -57,7 +73,8 @@ pub const CONTROL_KEY_CONTEXT: &str = "Control";
 ///
 /// Nothing in this crate claims `tab` for itself, deliberately. A multi-line
 /// field could reasonably insert one, but trapping `tab` inside a text box is
-/// the classic way to make a form impossible to leave by keyboard.
+/// the classic way to make a form impossible to leave by keyboard. A surface
+/// where the key is structural says so with [`CLAIMS_TAB`] instead.
 ///
 /// [`Decrement`]/[`Increment`] on `left`/`right` are for a control that holds a
 /// *value* rather than a press — [`slider`](crate::widgets::Controls::slider)
@@ -82,9 +99,32 @@ pub fn init(cx: &mut App) {
 ///
 /// It has to live on an element rather than on the app because moving focus
 /// needs a [`Window`], and an app-level action handler only gets an [`App`].
+///
+/// Where the focused surface [claims the key](CLAIMS_TAB), both handlers
+/// propagate instead: an action handler stops propagation by default, and
+/// continuing it is what sends gpui on to the next binding the chord matched.
 pub fn traversal(el: Div) -> Div {
-    el.on_action(|_: &FocusNext, window: &mut Window, cx: &mut App| window.focus_next(cx))
-        .on_action(|_: &FocusPrev, window: &mut Window, cx: &mut App| window.focus_prev(cx))
+    el.on_action(|_: &FocusNext, window: &mut Window, cx: &mut App| {
+        if claims_tab(window) {
+            return cx.propagate();
+        }
+        window.focus_next(cx);
+    })
+    .on_action(|_: &FocusPrev, window: &mut Window, cx: &mut App| {
+        if claims_tab(window) {
+            return cx.propagate();
+        }
+        window.focus_prev(cx);
+    })
+}
+
+/// The innermost context alone, not any in the path: a field *inside* a
+/// claiming surface still means "next control" by `tab`.
+fn claims_tab(window: &Window) -> bool {
+    window
+        .context_stack()
+        .last()
+        .is_some_and(|context| context.contains(CLAIMS_TAB))
 }
 
 /// Put a stateless control into the tab order, show when it holds focus, and

--- a/crates/ui/tests/focus.rs
+++ b/crates/ui/tests/focus.rs
@@ -1,0 +1,126 @@
+//! Tab traversal under gpui's own dispatcher: which binding answers the key,
+//! which no pure function can say.
+
+use gpui::{
+    Context, FocusHandle, IntoElement, KeyBinding, KeyContext, Render, TestAppContext,
+    VisualTestContext, Window, actions, div, prelude::*, px, size,
+};
+use ui::focus;
+
+actions!(focus_test, [Indent]);
+
+/// Two stops, the second optionally claiming `tab`. The root traverses.
+struct Host {
+    root: FocusHandle,
+    first: FocusHandle,
+    second: FocusHandle,
+    claims_tab: bool,
+    indented: bool,
+}
+
+impl Render for Host {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let mut context = KeyContext::default();
+        context.add("Surface");
+        if self.claims_tab {
+            context.add(focus::CLAIMS_TAB);
+        }
+        focus::traversal(div())
+            // No key context of its own, as an app's root view usually has
+            // none: the stack a key dispatches against is empty here.
+            .track_focus(&self.root)
+            .size_full()
+            .child(div().track_focus(&self.first.clone().tab_stop(true)))
+            .child(
+                div()
+                    .key_context(context)
+                    .track_focus(&self.second.clone().tab_stop(true))
+                    .on_action(cx.listener(|host: &mut Host, _: &Indent, _, _| {
+                        host.indented = true;
+                    })),
+            )
+    }
+}
+
+fn open(claims_tab: bool, cx: &mut TestAppContext) -> (gpui::Entity<Host>, VisualTestContext) {
+    cx.update(|cx| {
+        theme::Theme::install(theme::Appearance::Dark, cx);
+        // A surface's own binding, scoped to its context, bound *before*
+        // traversal's — the order that used to lose the tie.
+        cx.bind_keys([KeyBinding::new("tab", Indent, Some("Surface"))]);
+        focus::init(cx);
+    });
+    let window = cx.add_window(|_, cx| Host {
+        root: cx.focus_handle(),
+        first: cx.focus_handle(),
+        second: cx.focus_handle(),
+        claims_tab,
+        indented: false,
+    });
+    let host = window.root(cx).unwrap();
+    let visual = VisualTestContext::from_window(window.into(), cx);
+    visual.simulate_resize(size(px(200.0), px(200.0)));
+    visual.run_until_parked();
+    (host, visual)
+}
+
+/// A root view with no key context dispatches against an empty stack, which
+/// every predicate fails against — so a `!ClaimsTab` binding would leave this
+/// app no `tab` at all.
+#[gpui::test]
+fn tab_works_from_a_root_that_has_no_key_context(cx: &mut TestAppContext) {
+    let (host, mut cx) = open(false, cx);
+    cx.update(|window, cx| host.read(cx).root.clone().focus(window, cx));
+    cx.simulate_keystrokes("tab");
+    assert!(cx.update(|window, cx| host.read(cx).first.is_focused(window)));
+}
+
+#[gpui::test]
+fn tab_steps_between_stops(cx: &mut TestAppContext) {
+    let (host, mut cx) = open(false, cx);
+    cx.update(|window, cx| host.read(cx).first.clone().focus(window, cx));
+    cx.simulate_keystrokes("tab");
+    assert!(
+        cx.update(|window, cx| host.read(cx).second.is_focused(window)),
+        "tab moves on"
+    );
+    cx.simulate_keystrokes("shift-tab");
+    assert!(
+        cx.update(|window, cx| host.read(cx).first.is_focused(window)),
+        "and shift-tab back"
+    );
+    assert!(
+        !cx.update(|_, cx| host.read(cx).indented),
+        "a surface that never claimed the key was not asked to indent"
+    );
+}
+
+/// The bug behind #14: both bindings match at the same depth, and the tie went
+/// to traversal, bound last. Standing down hands the chord to the next one.
+#[gpui::test]
+fn a_surface_that_claims_tab_gets_the_key(cx: &mut TestAppContext) {
+    let (host, mut cx) = open(true, cx);
+    cx.update(|window, cx| host.read(cx).second.clone().focus(window, cx));
+    cx.simulate_keystrokes("tab");
+    assert!(
+        cx.update(|_, cx| host.read(cx).indented),
+        "the surface's own binding answered"
+    );
+    assert!(
+        cx.update(|window, cx| host.read(cx).second.is_focused(window)),
+        "and focus stayed put"
+    );
+}
+
+/// Claiming is per surface, not per window.
+#[gpui::test]
+fn a_claim_only_holds_while_that_surface_is_focused(cx: &mut TestAppContext) {
+    let (host, mut cx) = open(true, cx);
+    cx.update(|window, cx| host.read(cx).first.clone().focus(window, cx));
+    cx.simulate_keystrokes("tab");
+    assert!(
+        cx.update(|window, cx| host.read(cx).second.is_focused(window)),
+        "tab moved into the claiming surface rather than being swallowed"
+    );
+    assert!(!cx.update(|_, cx| host.read(cx).indented));
+}

--- a/www/docs/color.md
+++ b/www/docs/color.md
@@ -24,7 +24,7 @@ appearance::init(AppearanceMode::System, cx);
 
 Light is designed, not inverted. Mirroring lightness gets three things backwards: surface order (dark's content panel is the *darkest* plane, light's is white and the chrome goes grey), elevation (a faint white wash means "raised" on dark and "recessed" on light), and accents (the 400-level tones fall below 4.5:1 on white, so light uses the 600-level siblings at the same hue). Each light text token lands within ~0.5 of its dark counterpart's contrast ratio, and a test in the crate asserts it.
 
-`accent` is neutral by default. A library that ships a hue puts that hue in every app that installs it, so the default is the accent's lightness with the chroma at zero. Branding it is a [Brand](/docs/create), which rotates hue without moving any of the lightnesses above.
+`accent` is neutral by default. A library that ships a hue puts that hue in every app that installs it, so the default is the accent's lightness with the chroma at zero. Branding it is a [Brand](/docs/theme), which rotates hue without moving any of the lightnesses above.
 
 `set_palette` is the way in for colours a hue rotation cannot reach — a retuned `danger`, a wholesale replacement. Register the builder rather than installing one theme: `appearance::apply` rebuilds the palette from scratch on every light/dark switch, and a theme installed on its own lasts only until then.
 

--- a/www/docs/theme.md
+++ b/www/docs/theme.md
@@ -1,5 +1,5 @@
 ---
-title: Create
+title: Theme
 description: Pick a hue, a chroma and a radius, watch every component repaint, and copy the code that reproduces it.
 ---
 


### PR DESCRIPTION



https://github.com/user-attachments/assets/2ae4a195-d5a8-46f5-a67a-3f567171651a



## Changes


**Tab.** `tab` was bound twice — `Indent` in the editor's context, `FocusNext` by `ui::focus` with no context, which gpui gives the depth of the deepest one. The two tied, and a tie goes to whichever was bound last, so `init` order decided whether Tab indented. A surface that means something by `tab` now marks its key context with `focus::CLAIMS_TAB`, and traversal propagates instead of moving focus.

**Text size.** `cmd-+`/`cmd--`/`cmd-0` size the document, on Xcode and Zed's split: the app owns a base in points (`Editor::with_text_size`, from its own settings), the reader owns an in-memory adjustment shared by every open document, and reset clears the adjustment. Persistence stays the consumer's — `text_size_adjustment` reads it, `adjust_text_size` puts it back.

The base is absolute rather than a factor over the ladder, so moving the interface size leaves a document set to 16pt at 16pt.