### PR TITLE
feat(icons)!: use theme.icon to paint icons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - if: runner.os == 'Linux'
         run: sudo .github/scripts/linux-deps
-      - run: cargo build --workspace --all-targets
+      # nextest builds what it runs, so there is no separate build step; the
+      # one platform that lints `--all-targets` covers what a test run misses.
+      #
       # No fail-fast: one platform-specific test hiding the other 297 is not
       # a report anyone can act on.
       - run: cargo nextest run --workspace --no-fail-fast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bezel"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bezel-agent",
  "bezel-gpui",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-agent"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-blocks"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-editor"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bezel-gpui",
  "bezel-markdown",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-icons"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bezel-gpui",
  "usvg",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-markdown"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-motion"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-syntax"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bezel-theme",
  "tree-sitter",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-terminal"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "alacritty_terminal",
  "bezel-gpui",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-theme"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bezel-gpui",
  "objc",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-ui"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bezel-gpui",
  "bezel-icons",
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "gallery"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bezel-agent",
  "bezel-blocks",
@@ -2784,7 +2784,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bezel",
  "bezel-gpui",
@@ -4185,7 +4185,7 @@ dependencies = [
 
 [[package]]
 name = "parity"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bezel-gpui",
  "bezel-gpui-platform",
@@ -6872,7 +6872,7 @@ dependencies = [
 
 [[package]]
 name = "web"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bezel-gpui",
  "bezel-gpui-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bezel"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bezel-agent",
  "bezel-gpui",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-agent"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-blocks"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-editor"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bezel-gpui",
  "bezel-markdown",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-icons"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bezel-gpui",
  "usvg",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-markdown"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-motion"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-syntax"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bezel-theme",
  "tree-sitter",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-terminal"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "alacritty_terminal",
  "bezel-gpui",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-theme"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bezel-gpui",
  "objc",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "bezel-ui"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bezel-gpui",
  "bezel-icons",
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "gallery"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bezel-agent",
  "bezel-blocks",
@@ -2784,7 +2784,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bezel",
  "bezel-gpui",
@@ -4185,7 +4185,7 @@ dependencies = [
 
 [[package]]
 name = "parity"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bezel-gpui",
  "bezel-gpui-platform",
@@ -6872,7 +6872,7 @@ dependencies = [
 
 [[package]]
 name = "web"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bezel-gpui",
  "bezel-gpui-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 license = "MIT"
 authors = ["clearloop <tianyi.gc@gmail.com>"]
@@ -33,17 +33,17 @@ rust-version = "1.85"
 [workspace.dependencies]
 # The short names are taken on crates.io, so packages publish as `bezel-*`; the
 # key here and each crate's `[lib] name` are what the source imports.
-bezel = { path = "crates/bezel", version = "0.1.9" }
-agent = { package = "bezel-agent", path = "crates/agent", version = "0.1.9" }
-theme = { package = "bezel-theme", path = "crates/theme", version = "0.1.9" }
-motion = { package = "bezel-motion", path = "crates/motion", version = "0.1.9" }
-ui = { package = "bezel-ui", path = "crates/ui", version = "0.1.9" }
-icons = { package = "bezel-icons", path = "crates/icons", version = "0.1.9" }
-markdown = { package = "bezel-markdown", path = "crates/markdown", version = "0.1.9" }
-blocks = { package = "bezel-blocks", path = "crates/blocks", version = "0.1.9" }
-editor = { package = "bezel-editor", path = "crates/editor", version = "0.1.9" }
-syntax = { package = "bezel-syntax", path = "crates/syntax", version = "0.1.9" }
-terminal = { package = "bezel-terminal", path = "crates/terminal", version = "0.1.9" }
+bezel = { path = "crates/bezel", version = "0.1.10" }
+agent = { package = "bezel-agent", path = "crates/agent", version = "0.1.10" }
+theme = { package = "bezel-theme", path = "crates/theme", version = "0.1.10" }
+motion = { package = "bezel-motion", path = "crates/motion", version = "0.1.10" }
+ui = { package = "bezel-ui", path = "crates/ui", version = "0.1.10" }
+icons = { package = "bezel-icons", path = "crates/icons", version = "0.1.10" }
+markdown = { package = "bezel-markdown", path = "crates/markdown", version = "0.1.10" }
+blocks = { package = "bezel-blocks", path = "crates/blocks", version = "0.1.10" }
+editor = { package = "bezel-editor", path = "crates/editor", version = "0.1.10" }
+syntax = { package = "bezel-syntax", path = "crates/syntax", version = "0.1.10" }
+terminal = { package = "bezel-terminal", path = "crates/terminal", version = "0.1.10" }
 
 # crates-io
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tree-sitter-typescript = "0.23"
 tree-sitter-go = "0.25"
 tree-sitter-bash = "0.25"
 tree-sitter-toml-ng = "0.7"
-# Lucide. `bezel-icons` names 84 of its 1599 statics; the linker drops the rest.
+# Lucide. `bezel-icons` names 84 of its 1834 statics; the linker drops the rest.
 # The parser gpui paints SVGs with, used by the icon tests to prove a generated
 # document renders rather than merely looking like markup.
 usvg = "0.46"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 license = "MIT"
 authors = ["clearloop <tianyi.gc@gmail.com>"]
@@ -33,17 +33,17 @@ rust-version = "1.85"
 [workspace.dependencies]
 # The short names are taken on crates.io, so packages publish as `bezel-*`; the
 # key here and each crate's `[lib] name` are what the source imports.
-bezel = { path = "crates/bezel", version = "0.1.10" }
-agent = { package = "bezel-agent", path = "crates/agent", version = "0.1.10" }
-theme = { package = "bezel-theme", path = "crates/theme", version = "0.1.10" }
-motion = { package = "bezel-motion", path = "crates/motion", version = "0.1.10" }
-ui = { package = "bezel-ui", path = "crates/ui", version = "0.1.10" }
-icons = { package = "bezel-icons", path = "crates/icons", version = "0.1.10" }
-markdown = { package = "bezel-markdown", path = "crates/markdown", version = "0.1.10" }
-blocks = { package = "bezel-blocks", path = "crates/blocks", version = "0.1.10" }
-editor = { package = "bezel-editor", path = "crates/editor", version = "0.1.10" }
-syntax = { package = "bezel-syntax", path = "crates/syntax", version = "0.1.10" }
-terminal = { package = "bezel-terminal", path = "crates/terminal", version = "0.1.10" }
+bezel = { path = "crates/bezel", version = "0.1.11" }
+agent = { package = "bezel-agent", path = "crates/agent", version = "0.1.11" }
+theme = { package = "bezel-theme", path = "crates/theme", version = "0.1.11" }
+motion = { package = "bezel-motion", path = "crates/motion", version = "0.1.11" }
+ui = { package = "bezel-ui", path = "crates/ui", version = "0.1.11" }
+icons = { package = "bezel-icons", path = "crates/icons", version = "0.1.11" }
+markdown = { package = "bezel-markdown", path = "crates/markdown", version = "0.1.11" }
+blocks = { package = "bezel-blocks", path = "crates/blocks", version = "0.1.11" }
+editor = { package = "bezel-editor", path = "crates/editor", version = "0.1.11" }
+syntax = { package = "bezel-syntax", path = "crates/syntax", version = "0.1.11" }
+terminal = { package = "bezel-terminal", path = "crates/terminal", version = "0.1.11" }
 
 # crates-io
 libc = "0.2"

--- a/apps/gallery/src/lib.rs
+++ b/apps/gallery/src/lib.rs
@@ -24,7 +24,7 @@ use ui::{
     floating::{self, Floating},
     focus,
     hover_card::HoverCard,
-    icons,
+    icons::{self, Icon},
     input::{self, Shape, TextField},
     list, loaders,
     menu::Item,
@@ -41,8 +41,8 @@ use ui::{
     tree::{self, Direction, Move},
     widgets,
     widgets::{
-        ButtonStyle, Buttons, Content, Controls, Layout, Scaffolding, SliderDrag, SplitDrag,
-        SplitStyle, Status,
+        ButtonStyle, Buttons, Content, Controls, Icons as _, Layout, Scaffolding, SliderDrag,
+        SplitDrag, SplitStyle, Status,
     },
 };
 
@@ -1941,6 +1941,26 @@ impl Gallery {
                          filed under two is reachable through either. `icons::glyph` holds \
                          every one of them if the category is not worth remembering.",
                     ))
+                    .child(theme.field_label("Painting one"))
+                    .child(
+                        div()
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .gap(px(14.0))
+                            .child(theme.icon(icons::glyph::Star))
+                            .child(theme.icon(Icon::glyph(icons::glyph::Star).solid()))
+                            .child(theme.icon_at(TextStyle::Title2, icons::glyph::Star))
+                            .child(theme.icon(icons::glyph::Star).text_color(theme.accent)),
+                    )
+                    .child(hint(
+                        &theme,
+                        "`theme.icon` takes its size from the type ladder and its tone from \
+                         the palette, so an icon set nowhere still paints — a `Styled` call \
+                         after it wins, which is how a component keeps its own metric. \
+                         `Icon::solid` is the filled variant, `theme.icon_at` another rung, \
+                         and `Icon::path` art the app resolves itself.",
+                    ))
                     .child(theme.field_label("Cargo"))
                     .child(markdown::render(
                         &self.icons_cargo,
@@ -2683,7 +2703,7 @@ impl Gallery {
                                 let key = Fade::new(view, format!("nav-row-{index}"));
                                 let row = theme
                                     .nav_row(
-                                        Some(*icon),
+                                        Some(Icon::glyph(icon)),
                                         *label,
                                         self.nav_choice == index,
                                         key.clone(),

--- a/apps/gallery/src/lib.rs
+++ b/apps/gallery/src/lib.rs
@@ -406,8 +406,14 @@ fn demo_menus() -> Vec<Menu> {
         Menu::new(
             "File",
             vec![
-                Item::action("New Window").with_keystroke("⌘N"),
+                // The File menu is the one that carries glyphs: the gutter
+                // only appears where a row has one, so a demo without it would
+                // never show that column.
+                Item::action("New Window")
+                    .with_icon(icons::glyph::FilePlus)
+                    .with_keystroke("⌘N"),
                 Item::action("Open…")
+                    .with_icon(icons::glyph::FolderOpen)
                     .with_keystroke("⌘O")
                     .with_description("Choose a markdown file to edit"),
                 Item::submenu(
@@ -420,8 +426,13 @@ fn demo_menus() -> Vec<Menu> {
                     ],
                 ),
                 Item::Separator,
-                Item::action("Save").with_keystroke("⌘S"),
-                Item::action("Save As…").with_keystroke("⇧⌘S").disabled(),
+                Item::action("Save")
+                    .with_icon(icons::glyph::Save)
+                    .with_keystroke("⌘S"),
+                Item::action("Save As…")
+                    .with_icon(icons::glyph::Save)
+                    .with_keystroke("⇧⌘S")
+                    .disabled(),
             ],
         ),
         Menu::new(

--- a/apps/gallery/src/patterns/transcript.rs
+++ b/apps/gallery/src/patterns/transcript.rs
@@ -269,7 +269,7 @@ impl Transcript {
             .child(
                 theme
                     .step_row(
-                        icon,
+                        *icon,
                         *verb,
                         Some(SharedString::from(*detail)),
                         Some(SharedString::from(if *ms < 1000 {

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,17 @@
 [
   {
+    "version": "0.1.10",
+    "date": "2026-09-13",
+    "summary": "A menu row's glyph paints again, and `bezel-icons` carries a README of its own.",
+    "changed": [
+      "`menu::Item::with_icon` takes an icon constant rather than an asset path, which is what every other component has taken since the set was ported. `Item`'s `icon` field is the glyph itself, so a row's icon is linked like any other.",
+      "`bezel-icons` publishes its own README rather than the workspace's — the features, the names and the pinned-release upgrade, where a consumer of the crate alone will look for them."
+    ],
+    "fixed": [
+      "A menu row's leading glyph painted nothing. `menu` was the one component the icon port left holding an asset path, and bezel registers no asset source, so the gutter opened and stayed empty. The demo menus carry glyphs now, which is what would have shown it."
+    ]
+  },
+  {
     "version": "0.1.9",
     "date": "2026-09-13",
     "summary": "The icon set becomes the whole of Lucide, ported from a pinned release and named the way Lucide names it.",

--- a/changelog.json
+++ b/changelog.json
@@ -1,12 +1,12 @@
 [
   {
-    "version": "0.1.10",
+    "version": "0.1.11",
     "date": "2026-09-13",
     "summary": "An icon is a value now — `Icon` — and `theme.icon` paints one from the ladder and the palette.",
     "new": [
       "`icons::Icon` is what a component takes, and it erases where the drawing came from: a glyph compiled in, `Icon::asset(..)` out of the app's own `AssetSource`, or `Icon::file(..)` off disk. Every icon-taking signature moves to `impl Into<Icon>`, so a constant still passes as itself and an app can finally paint art the set does not carry. SwiftUI's `Image` erases its sources the same way.",
       "`theme.icon(..)` and `theme.icon_at(role, ..)` paint an icon at a rung of the type ladder in the palette's text tone. Both are defaults a `Styled` call after them overrides, which is how a component keeps its own metric — what they buy is the floor: gpui resolves an svg's tone from that element's own style and never inherits one, so an icon with nothing set paints *nothing*. It is a catalog trait like the rest, `use ui::widgets::Icons`.",
-      "`Icon::solid` is the filled variant as a property of the value rather than a second call — SwiftUI's `.symbolVariant(.fill)`. `icons::solid(..)` stays for the common case.",
+      "`Icon::solid` is the filled variant as a property of the value rather than a second call — SwiftUI's `.symbolVariant(.fill)`. `icons::solid(..)` stays for the common case, and the filled document is now rewritten once per glyph and kept rather than rebuilt on every frame a solid icon is on screen.",
       "`bezel-icons` publishes a README of its own: the features, the names, and how the pinned-release upgrade works."
     ],
     "fixed": [

--- a/changelog.json
+++ b/changelog.json
@@ -2,10 +2,12 @@
   {
     "version": "0.1.10",
     "date": "2026-09-13",
-    "summary": "A menu row's glyph paints again, and `bezel-icons` carries a README of its own.",
-    "changed": [
-      "`menu::Item::with_icon` takes an icon constant rather than an asset path, which is what every other component has taken since the set was ported. `Item`'s `icon` field is the glyph itself, so a row's icon is linked like any other.",
-      "`bezel-icons` publishes its own README rather than the workspace's — the features, the names and the pinned-release upgrade, where a consumer of the crate alone will look for them."
+    "summary": "An icon is a value now — `Icon` — and `theme.icon` paints one from the ladder and the palette.",
+    "new": [
+      "`icons::Icon` is what a component takes, and it erases where the drawing came from: a glyph compiled in, or `Icon::path(..)` the app's own `AssetSource` resolves at runtime. Every icon-taking signature moves to `impl Into<Icon>`, so a constant still passes as itself and an app can finally paint art the set does not carry. SwiftUI's `Image` erases its sources the same way.",
+      "`theme.icon(..)` and `theme.icon_at(role, ..)` paint an icon at a rung of the type ladder in the palette's text tone. Both are defaults a `Styled` call after them overrides, which is how a component keeps its own metric — what they buy is the floor: gpui resolves an svg's tone from that element's own style and never inherits one, so an icon with nothing set paints *nothing*. It is a catalog trait like the rest, `use ui::widgets::Icons`.",
+      "`Icon::solid` is the filled variant as a property of the value rather than a second call — SwiftUI's `.symbolVariant(.fill)`. `icons::solid(..)` stays for the common case.",
+      "`bezel-icons` publishes a README of its own: the features, the names, and how the pinned-release upgrade works."
     ],
     "fixed": [
       "A menu row's leading glyph painted nothing. `menu` was the one component the icon port left holding an asset path, and bezel registers no asset source, so the gutter opened and stayed empty. The demo menus carry glyphs now, which is what would have shown it."

--- a/changelog.json
+++ b/changelog.json
@@ -4,7 +4,7 @@
     "date": "2026-09-13",
     "summary": "An icon is a value now — `Icon` — and `theme.icon` paints one from the ladder and the palette.",
     "new": [
-      "`icons::Icon` is what a component takes, and it erases where the drawing came from: a glyph compiled in, or `Icon::path(..)` the app's own `AssetSource` resolves at runtime. Every icon-taking signature moves to `impl Into<Icon>`, so a constant still passes as itself and an app can finally paint art the set does not carry. SwiftUI's `Image` erases its sources the same way.",
+      "`icons::Icon` is what a component takes, and it erases where the drawing came from: a glyph compiled in, `Icon::asset(..)` out of the app's own `AssetSource`, or `Icon::file(..)` off disk. Every icon-taking signature moves to `impl Into<Icon>`, so a constant still passes as itself and an app can finally paint art the set does not carry. SwiftUI's `Image` erases its sources the same way.",
       "`theme.icon(..)` and `theme.icon_at(role, ..)` paint an icon at a rung of the type ladder in the palette's text tone. Both are defaults a `Styled` call after them overrides, which is how a component keeps its own metric — what they buy is the floor: gpui resolves an svg's tone from that element's own style and never inherits one, so an icon with nothing set paints *nothing*. It is a catalog trait like the rest, `use ui::widgets::Icons`.",
       "`Icon::solid` is the filled variant as a property of the value rather than a second call — SwiftUI's `.symbolVariant(.fill)`. `icons::solid(..)` stays for the common case.",
       "`bezel-icons` publishes a README of its own: the features, the names, and how the pinned-release upgrade works."

--- a/crates/icons/Cargo.toml
+++ b/crates/icons/Cargo.toml
@@ -7,14 +7,16 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
+# Not the workspace README: an inherited `readme` resolves against the workspace
+# root, and this crate has one of its own.
+readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
 # `assets/` and `src/generated.rs` are gitignored, and cargo packages from the
 # VCS listing unless told otherwise. Naming them here is what puts the ported
 # glyphs inside the published crate, so a consumer never runs the download.
-include = ["src/**/*.rs", "assets/**", "build.rs", "tests/**/*.rs"]
+include = ["src/**/*.rs", "assets/**", "build.rs", "tests/**/*.rs", "README.md"]
 
 [lib]
 name = "icons"

--- a/crates/icons/README.md
+++ b/crates/icons/README.md
@@ -1,0 +1,59 @@
+# bezel-icons
+
+[![crates.io](https://img.shields.io/crates/v/bezel-icons.svg?style=flat-square)](https://crates.io/crates/bezel-icons)
+[![docs.rs](https://img.shields.io/docsrs/bezel-icons?style=flat-square)](https://docs.rs/bezel-icons)
+[![license](https://img.shields.io/crates/l/bezel-icons.svg?style=flat-square)](../../LICENSE)
+
+The [Lucide] set — 1834 glyphs, ported from a pinned release into typed
+constants for [gpui]. Part of [bezel], and reached as `bezel::icons` from it.
+
+```toml
+[dependencies]
+icons = { package = "bezel-icons", version = "0.1", features = ["navigation"] }
+```
+
+```rust
+use icons::{icon, navigation::Compass};
+
+icon(Compass).size(px(16.0)).text_color(theme.text_muted)
+```
+
+[`icon`] returns a gpui `Svg`, so it colors with `text_color` and sizes like any
+element. [`solid`] paints the same glyph filled, with the outer edge where
+[`icon`] puts it, so a control swapping between them does not jump.
+
+## Paying for what you paint
+
+A constant is the SVG itself, not a path into an asset source — nothing
+registers with `with_assets`, and the linker drops a glyph the app never names.
+
+Features are Lucide's 42 categories under Lucide's own names, and `full` is all
+of them. Nothing is on by default. Cargo unions features across a graph, so a
+category a dependency turns on is the floor for everyone below it.
+
+`CATEGORIES` is every enabled category and its icons, for an icon browser.
+Naming it pins the enabled set, so an app that only paints icons never mentions
+it and keeps the dead-code pass.
+
+## Names
+
+Modules are Lucide's categories and constants are Lucide's names, both generated
+from the release: a name copied off [lucide.dev](https://lucide.dev) compiles
+here. A glyph Lucide files under two categories is one constant re-exported
+twice, so `glyph` holds each exactly once.
+
+## Upgrading
+
+`LUCIDE` in `build.rs` is the pinned release. Bumping it invalidates the index
+beside the assets and the next build re-ports, so the diff shows which glyphs
+upstream redrew. The port runs only in a fresh checkout — the published crate
+carries the glyphs, which is what keeps it offline, vendorable and buildable on
+docs.rs.
+
+Icons are Lucide, under the [ISC license](https://lucide.dev/license).
+
+[bezel]: https://github.com/crabtalk/bezel
+[gpui]: https://github.com/zed-industries/zed/tree/main/crates/gpui
+[lucide]: https://lucide.dev
+[`icon`]: https://docs.rs/bezel-icons/latest/icons/fn.icon.html
+[`solid`]: https://docs.rs/bezel-icons/latest/icons/fn.solid.html

--- a/crates/icons/README.md
+++ b/crates/icons/README.md
@@ -13,14 +13,32 @@ icons = { package = "bezel-icons", version = "0.1", features = ["navigation"] }
 ```
 
 ```rust
-use icons::{icon, navigation::Compass};
+use icons::{Icon, navigation::Compass};
 
-icon(Compass).size(px(16.0)).text_color(theme.text_muted)
+theme.icon(Compass)                          // ladder step, palette tone
+theme.icon(Icon::glyph(Compass).solid())     // the filled variant
+icons::icon(Compass).size(px(16.0)).text_color(theme.text_muted)
 ```
 
 [`icon`] returns a gpui `Svg`, so it colors with `text_color` and sizes like any
-element. [`solid`] paints the same glyph filled, with the outer edge where
-[`icon`] puts it, so a control swapping between them does not jump.
+element — but gpui reads an svg's tone from that element's own style and never
+inherits one, so an icon with neither set paints nothing. `bezel-ui`'s
+`theme.icon(..)` is this same builder with both supplied, which is what app code
+should reach for; a component that has its own metric sets it on top.
+
+## What a component takes
+
+[`Icon`] is the value, and it erases where the drawing came from — a glyph
+compiled in, or `Icon::path("brand/mark.svg")` the app's own `AssetSource`
+resolves at runtime. Components take `impl Into<Icon>`, so a constant passes as
+itself and neither the signature nor the component learns which it got.
+SwiftUI's `Image` erases its sources the same way.
+
+An `Icon` carries no size and no color. Those belong to the environment, which
+here is the component: a menu row's glyph is the row's metric, not the caller's.
+`Icon::solid` is the one thing it does carry — SwiftUI's `.symbolVariant(.fill)`
+— and it fills the outline where [`icon`] draws it, so a control swapping
+between them does not jump.
 
 ## Paying for what you paint
 
@@ -57,3 +75,4 @@ Icons are Lucide, under the [ISC license](https://lucide.dev/license).
 [lucide]: https://lucide.dev
 [`icon`]: https://docs.rs/bezel-icons/latest/icons/fn.icon.html
 [`solid`]: https://docs.rs/bezel-icons/latest/icons/fn.solid.html
+[`Icon`]: https://docs.rs/bezel-icons/latest/icons/struct.Icon.html

--- a/crates/icons/README.md
+++ b/crates/icons/README.md
@@ -28,11 +28,17 @@ should reach for; a component that has its own metric sets it on top.
 
 ## What a component takes
 
-[`Icon`] is the value, and it erases where the drawing came from — a glyph
-compiled in, or `Icon::path("brand/mark.svg")` the app's own `AssetSource`
-resolves at runtime. Components take `impl Into<Icon>`, so a constant passes as
-itself and neither the signature nor the component learns which it got.
-SwiftUI's `Image` erases its sources the same way.
+[`Icon`] is the value, and it erases where the drawing came from:
+
+```rust
+theme.row_icon(glyph::Monitor)                  // a glyph compiled in
+theme.row_icon(Icon::asset("brand/mark.svg"))   // the app's own AssetSource
+theme.row_icon(Icon::file(picked))              // a file on disk
+```
+
+Components take `impl Into<Icon>`, so a constant passes as itself and neither
+the signature nor the component learns which it got. SwiftUI's `Image` erases
+its sources the same way.
 
 An `Icon` carries no size and no color. Those belong to the environment, which
 here is the component: a menu row's glyph is the row's metric, not the caller's.

--- a/crates/icons/src/lib.rs
+++ b/crates/icons/src/lib.rs
@@ -7,7 +7,20 @@
 //! ```
 //!
 //! [`icon`] returns a gpui `Svg`, so it colors with `text_color` and sizes like
-//! any element.
+//! any element. `ui`'s `theme.icon(..)` is the same builder with both supplied
+//! from the ladder and the palette, which is what app code should reach for.
+//!
+//! # What a component takes
+//!
+//! [`Icon`] is the value, and it erases where the drawing came from — a glyph
+//! compiled in, or a path the app's own `AssetSource` resolves. Components take
+//! `impl Into<Icon>`, so `glyph::Search` passes as itself and an app's own art
+//! passes as [`Icon::path`], and neither the component nor its signature learns
+//! which it got. SwiftUI's `Image` erases its sources the same way.
+//!
+//! An `Icon` carries no size and no colour. Those are the environment's, which
+//! here is the component: a menu row's glyph is the row's metric, not the
+//! caller's.
 //!
 //! # The set
 //!
@@ -42,19 +55,92 @@ mod generated {
 
 pub use generated::*;
 
-use gpui::{Styled as _, Svg, svg};
+use std::borrow::Cow;
 
-/// An icon element for a glyph from the set. Size and color are the caller's
-/// (`.size(..)`, `.text_color(..)`), matching the `[&_svg]:size-4` idiom.
-pub fn icon(glyph: &'static [u8]) -> Svg {
-    svg().data(glyph).flex_none()
+use gpui::{SharedString, Styled as _, Svg, svg};
+
+/// What to paint: a drawing, and the variant of it. Every component that takes
+/// an icon takes this, so a glyph and an app's own file are one signature.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Icon {
+    source: Source,
+    fill: bool,
 }
 
-/// The same glyph painted solid. Lucide draws one weight, so this fills the
-/// outline rather than reaching for a second drawing: filling *and* stroking
-/// keeps the outer edge exactly where [`icon`] puts it, so a control swapping
-/// between them — favourited or not — does not jump.
-pub fn solid(glyph: &'static [u8]) -> Svg {
-    let filled = String::from_utf8_lossy(glyph).replace(r#"fill="none""#, r#"fill="currentColor""#);
-    svg().data(filled.as_bytes()).flex_none()
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Source {
+    /// A glyph from the set, or any SVG the binary compiled in.
+    Glyph(&'static [u8]),
+    /// A path the app's own `AssetSource` resolves at runtime.
+    Path(SharedString),
+}
+
+impl Icon {
+    /// A glyph from the set — `Icon::glyph(glyph::Search)`. `const`, so a
+    /// component can hold one as a default and the linker still drops the rest.
+    pub const fn glyph(svg: &'static [u8]) -> Self {
+        Self {
+            source: Source::Glyph(svg),
+            fill: false,
+        }
+    }
+
+    /// Art of the app's own, resolved by its `AssetSource` at paint time. The
+    /// set cannot cover a product's marks, and the alternative is an app that
+    /// cannot use its own.
+    pub fn path(path: impl Into<SharedString>) -> Self {
+        Self {
+            source: Source::Path(path.into()),
+            fill: false,
+        }
+    }
+
+    /// Filled rather than outlined — SwiftUI's `.symbolVariant(.fill)`. Lucide
+    /// draws one weight, so this fills the outline rather than reaching for a
+    /// second drawing: filling *and* stroking keeps the outer edge exactly
+    /// where the outline puts it, so a control swapping between them —
+    /// favourited or not — does not jump.
+    pub fn solid(mut self) -> Self {
+        self.fill = true;
+        self
+    }
+
+    /// The document to paint, for a glyph: the ported bytes, or the filled
+    /// rewrite of them. `None` for a path, which only the renderer resolves.
+    pub fn data(&self) -> Option<Cow<'static, [u8]>> {
+        let Source::Glyph(glyph) = self.source else {
+            return None;
+        };
+        Some(match self.fill {
+            false => Cow::Borrowed(glyph),
+            true => Cow::Owned(
+                String::from_utf8_lossy(glyph)
+                    .replace(r#"fill="none""#, r#"fill="currentColor""#)
+                    .into_bytes(),
+            ),
+        })
+    }
+}
+
+impl From<&'static [u8]> for Icon {
+    fn from(glyph: &'static [u8]) -> Self {
+        Self::glyph(glyph)
+    }
+}
+
+/// An icon element. Size and colour are the caller's (`.size(..)`,
+/// `.text_color(..)`) — an `Svg` with neither paints nothing, which is why
+/// `ui`'s `theme.icon(..)` supplies both and this is the floor under it.
+pub fn icon(icon: impl Into<Icon>) -> Svg {
+    let icon = icon.into();
+    match &icon.source {
+        Source::Glyph(_) => svg().data(&icon.data().expect("a glyph carries its own document")),
+        Source::Path(path) => svg().path(path.clone()),
+    }
+    .flex_none()
+}
+
+/// [`icon`], painted solid — `icons::solid(glyph::Play)`.
+pub fn solid(icon: impl Into<Icon>) -> Svg {
+    self::icon(icon.into().solid())
 }

--- a/crates/icons/src/lib.rs
+++ b/crates/icons/src/lib.rs
@@ -13,10 +13,10 @@
 //! # What a component takes
 //!
 //! [`Icon`] is the value, and it erases where the drawing came from — a glyph
-//! compiled in, or a path the app's own `AssetSource` resolves. Components take
-//! `impl Into<Icon>`, so `glyph::Search` passes as itself and an app's own art
-//! passes as [`Icon::path`], and neither the component nor its signature learns
-//! which it got. SwiftUI's `Image` erases its sources the same way.
+//! compiled in, the app's [`Icon::asset`] source, or [`Icon::file`] off disk.
+//! Components take `impl Into<Icon>`, so `glyph::Search` passes as itself and
+//! neither the component nor its signature learns which it got. SwiftUI's
+//! `Image` erases its sources the same way.
 //!
 //! An `Icon` carries no size and no colour. Those are the environment's, which
 //! here is the component: a menu row's glyph is the row's metric, not the
@@ -55,7 +55,10 @@ mod generated {
 
 pub use generated::*;
 
-use std::borrow::Cow;
+use std::{
+    collections::HashMap,
+    sync::{OnceLock, PoisonError, RwLock},
+};
 
 use gpui::{SharedString, Styled as _, Svg, svg};
 
@@ -71,8 +74,10 @@ pub struct Icon {
 enum Source {
     /// A glyph from the set, or any SVG the binary compiled in.
     Glyph(&'static [u8]),
-    /// A path the app's own `AssetSource` resolves at runtime.
-    Path(SharedString),
+    /// A key the app's own `AssetSource` resolves.
+    Asset(SharedString),
+    /// A file read from disk at paint time.
+    File(SharedString),
 }
 
 impl Icon {
@@ -85,12 +90,22 @@ impl Icon {
         }
     }
 
-    /// Art of the app's own, resolved by its `AssetSource` at paint time. The
-    /// set cannot cover a product's marks, and the alternative is an app that
-    /// cannot use its own.
-    pub fn path(path: impl Into<SharedString>) -> Self {
+    /// Art of the app's own, out of the `AssetSource` it registered. The set
+    /// cannot cover a product's marks, and a library that took only its own
+    /// would be one an app cannot put its logo in.
+    pub fn asset(key: impl Into<SharedString>) -> Self {
         Self {
-            source: Source::Path(path.into()),
+            source: Source::Asset(key.into()),
+            fill: false,
+        }
+    }
+
+    /// A file on disk, for art that was not there at build time — one the user
+    /// picked, one a fetch wrote down. gpui loads it off the paint thread and
+    /// caches it, so the first frame or two paint nothing.
+    pub fn file(path: impl Into<SharedString>) -> Self {
+        Self {
+            source: Source::File(path.into()),
             fill: false,
         }
     }
@@ -106,20 +121,51 @@ impl Icon {
     }
 
     /// The document to paint, for a glyph: the ported bytes, or the filled
-    /// rewrite of them. `None` for a path, which only the renderer resolves.
-    pub fn data(&self) -> Option<Cow<'static, [u8]>> {
+    /// rewrite of them. `None` for art, which only the renderer resolves.
+    pub fn data(&self) -> Option<&'static [u8]> {
         let Source::Glyph(glyph) = self.source else {
             return None;
         };
         Some(match self.fill {
-            false => Cow::Borrowed(glyph),
-            true => Cow::Owned(
-                String::from_utf8_lossy(glyph)
-                    .replace(r#"fill="none""#, r#"fill="currentColor""#)
-                    .into_bytes(),
-            ),
+            false => glyph,
+            true => filled(glyph),
         })
     }
+}
+
+/// The filled rewrite of one glyph, made once and kept for the process.
+///
+/// [`Icon::solid`] is a flag read at paint time rather than a second constant,
+/// so without this the rewrite runs on every frame a solid icon is on screen.
+/// Keyed by the glyph's own address, which is stable and unique per constant —
+/// one filed under two categories is still one constant. Leaked rather than
+/// freed: an entry costs one glyph and is bounded by how many an app fills.
+fn filled(glyph: &'static [u8]) -> &'static [u8] {
+    static FILLED: OnceLock<RwLock<HashMap<usize, &'static [u8]>>> = OnceLock::new();
+
+    let cache = FILLED.get_or_init(RwLock::default);
+    let key = glyph.as_ptr() as usize;
+    // Read first: painting is the hot path, and after the first frame every
+    // glyph an app fills is already here.
+    if let Some(filled) = cache
+        .read()
+        .unwrap_or_else(PoisonError::into_inner)
+        .get(&key)
+    {
+        return filled;
+    }
+
+    let filled: &'static [u8] = Box::leak(
+        String::from_utf8_lossy(glyph)
+            .replace(r#"fill="none""#, r#"fill="currentColor""#)
+            .into_bytes()
+            .into_boxed_slice(),
+    );
+    cache
+        .write()
+        .unwrap_or_else(PoisonError::into_inner)
+        .insert(key, filled);
+    filled
 }
 
 impl From<&'static [u8]> for Icon {
@@ -134,8 +180,9 @@ impl From<&'static [u8]> for Icon {
 pub fn icon(icon: impl Into<Icon>) -> Svg {
     let icon = icon.into();
     match &icon.source {
-        Source::Glyph(_) => svg().data(&icon.data().expect("a glyph carries its own document")),
-        Source::Path(path) => svg().path(path.clone()),
+        Source::Glyph(_) => svg().data(icon.data().expect("a glyph carries its own document")),
+        Source::Asset(key) => svg().path(key.clone()),
+        Source::File(path) => svg().external_path(path.clone()),
     }
     .flex_none()
 }

--- a/crates/icons/tests/icons.rs
+++ b/crates/icons/tests/icons.rs
@@ -1,5 +1,7 @@
 use std::{fs, path::PathBuf};
 
+use icons::Icon;
+
 fn assets() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets")
 }
@@ -110,11 +112,30 @@ fn a_solid_twin_is_its_outline_painted_in() {
     let outline = std::str::from_utf8(icons::glyph::Heart).unwrap();
     assert!(outline.contains(r#"fill="none""#), "the outline is filled");
 
-    let filled = outline.replace(r#"fill="none""#, r#"fill="currentColor""#);
-    let body = |svg: &str| svg[svg.find('>').unwrap()..].to_owned();
-    assert_eq!(
-        body(outline),
-        body(&filled),
-        "the solid twin moved the path"
+    let filled = Icon::glyph(icons::glyph::Heart)
+        .solid()
+        .data()
+        .expect("a glyph carries its own document");
+    let filled = std::str::from_utf8(&filled).unwrap();
+    assert!(
+        filled.contains(r#"fill="currentColor""#),
+        "the solid twin is not filled"
     );
+
+    let body = |svg: &str| svg[svg.find('>').unwrap()..].to_owned();
+    assert_eq!(body(outline), body(filled), "the solid twin moved the path");
+}
+
+/// A component takes an [`Icon`] and never learns which kind it was handed.
+/// Only the renderer asks, and this is what it asks.
+#[test]
+fn an_icon_erases_where_the_drawing_came_from() {
+    assert_eq!(
+        Icon::from(icons::glyph::Heart).data().as_deref(),
+        Some(icons::glyph::Heart),
+        "a glyph lost its document"
+    );
+    // Resolved by the app's own `AssetSource` at paint time, so there is
+    // nothing for this side to hand a parser.
+    assert_eq!(Icon::path("brand/mark.svg").data(), None);
 }

--- a/crates/icons/tests/icons.rs
+++ b/crates/icons/tests/icons.rs
@@ -116,7 +116,7 @@ fn a_solid_twin_is_its_outline_painted_in() {
         .solid()
         .data()
         .expect("a glyph carries its own document");
-    let filled = std::str::from_utf8(&filled).unwrap();
+    let filled = std::str::from_utf8(filled).unwrap();
     assert!(
         filled.contains(r#"fill="currentColor""#),
         "the solid twin is not filled"
@@ -131,11 +131,13 @@ fn a_solid_twin_is_its_outline_painted_in() {
 #[test]
 fn an_icon_erases_where_the_drawing_came_from() {
     assert_eq!(
-        Icon::from(icons::glyph::Heart).data().as_deref(),
+        Icon::from(icons::glyph::Heart).data(),
         Some(icons::glyph::Heart),
         "a glyph lost its document"
     );
-    // Resolved by the app's own `AssetSource` at paint time, so there is
-    // nothing for this side to hand a parser.
-    assert_eq!(Icon::path("brand/mark.svg").data(), None);
+    // Both kinds of art are resolved by the renderer at paint time — one
+    // through the app's `AssetSource`, one off disk — so there is nothing for
+    // this side to hand a parser.
+    assert_eq!(Icon::asset("brand/mark.svg").data(), None);
+    assert_eq!(Icon::file("/tmp/mark.svg").data(), None);
 }

--- a/crates/ui/src/control_bar.rs
+++ b/crates/ui/src/control_bar.rs
@@ -42,6 +42,7 @@
 //! ```
 
 use gpui::{AnyElement, IntoElement, ParentElement as _, Styled as _, div, px};
+use icons::Icon;
 use theme::{TextStyle, Theme, Typeset, hairline};
 
 use crate::surface::Surfaced as _;
@@ -130,7 +131,7 @@ pub fn control_bar(
 /// Caller adds id, click and its own `.hover(..)`: gpui panics on a second
 /// hover call, and the wash differs by state (a lit toggle is not a resting
 /// one). [`Theme::element_hover`] is the wash to reach for.
-pub fn bar_button(icon: &'static [u8], diameter: f32, tint: gpui::Hsla) -> gpui::Div {
+pub fn bar_button(icon: impl Into<Icon>, diameter: f32, tint: gpui::Hsla) -> gpui::Div {
     div()
         .flex_none()
         .size(px(diameter))

--- a/crates/ui/src/date.rs
+++ b/crates/ui/src/date.rs
@@ -29,6 +29,7 @@ use gpui::{
     App, Context, EventEmitter, FocusHandle, Focusable, KeyBinding, SharedString, Window, actions,
     div, prelude::*, px,
 };
+use icons::Icon;
 
 use theme::{TextStyle, Theme, Typeset};
 
@@ -470,7 +471,7 @@ impl Calendar {
 const CELL: f32 = 30.0;
 
 /// A month arrow in the card's header.
-fn month_step(theme: &Theme, icon: &'static [u8]) -> gpui::Div {
+fn month_step(theme: &Theme, icon: impl Into<Icon>) -> gpui::Div {
     div()
         .size(px(24.0))
         .rounded(px(Theme::control_radius()))

--- a/crates/ui/src/menu.rs
+++ b/crates/ui/src/menu.rs
@@ -43,10 +43,9 @@ pub enum Item {
         /// because a row's two lines read as one block and a blank second line
         /// would read as a gap.
         description: Option<SharedString>,
-        /// The leading glyph's asset path — [`crate::icons`]' consts, or a
-        /// path the app resolved at runtime. A menu where no row has one keeps
-        /// no room for it.
-        icon: Option<SharedString>,
+        /// The leading glyph, a [`crate::icons`] const. A menu where no row
+        /// has one keeps no room for it.
+        icon: Option<&'static [u8]>,
         /// The accelerator to *print* — the binding itself is the app's, and
         /// bezel never dispatches it. A menu that showed a keystroke it did not
         /// own would be documenting a lie.
@@ -60,7 +59,7 @@ pub enum Item {
     /// only thing choosing it does is open.
     Submenu {
         label: SharedString,
-        icon: Option<SharedString>,
+        icon: Option<&'static [u8]>,
         enabled: bool,
         items: Vec<Item>,
     },
@@ -89,10 +88,10 @@ impl Item {
     }
 
     /// No-ops on a separator, which has nothing to hang a glyph on.
-    pub fn with_icon(mut self, icon: impl Into<SharedString>) -> Self {
+    pub fn with_icon(mut self, icon: &'static [u8]) -> Self {
         match &mut self {
             Item::Action { icon: slot, .. } | Item::Submenu { icon: slot, .. } => {
-                *slot = Some(icon.into())
+                *slot = Some(icon)
             }
             Item::Separator => {}
         }
@@ -462,7 +461,7 @@ impl<V: 'static> Tree<V> {
                         icon,
                         enabled,
                         ..
-                    } => (label.clone(), icon.clone(), *enabled),
+                    } => (label.clone(), *icon, *enabled),
                     Item::Separator => unreachable!("separators returned above"),
                 };
                 let description = match item {
@@ -579,22 +578,19 @@ fn row_id(id: &SharedString, path: &[usize]) -> SharedString {
 
 /// The leading column: the row's glyph, or the room one would have taken, so a
 /// menu of mixed rows keeps its labels on one edge.
-fn glyph_slot(theme: &Theme, icon: Option<SharedString>, enabled: bool) -> gpui::Div {
+fn glyph_slot(theme: &Theme, icon: Option<&'static [u8]>, enabled: bool) -> gpui::Div {
     div()
         .flex_none()
         .size(px(GLYPH))
         .flex()
         .items_center()
         .justify_center()
-        .children(icon.map(|path| {
-            gpui::svg()
-                .path(path)
-                .size(px(GLYPH))
-                .text_color(if enabled {
-                    theme.text_faint
-                } else {
-                    theme.text_faint.opacity(0.5)
-                })
+        .children(icon.map(|glyph| {
+            icons::icon(glyph).size(px(GLYPH)).text_color(if enabled {
+                theme.text_faint
+            } else {
+                theme.text_faint.opacity(0.5)
+            })
         }))
 }
 

--- a/crates/ui/src/menu.rs
+++ b/crates/ui/src/menu.rs
@@ -13,6 +13,7 @@
 
 use crate::{icons, popover};
 use gpui::{Context, MouseDownEvent, Pixels, Point, SharedString, Window, div, prelude::*, px};
+use icons::Icon;
 use std::{cell::Cell, rc::Rc};
 use theme::{TextStyle, Theme, Typeset};
 
@@ -43,9 +44,9 @@ pub enum Item {
         /// because a row's two lines read as one block and a blank second line
         /// would read as a gap.
         description: Option<SharedString>,
-        /// The leading glyph, a [`crate::icons`] const. A menu where no row
-        /// has one keeps no room for it.
-        icon: Option<&'static [u8]>,
+        /// The leading glyph. A menu where no row has one keeps no room
+        /// for it.
+        icon: Option<Icon>,
         /// The accelerator to *print* — the binding itself is the app's, and
         /// bezel never dispatches it. A menu that showed a keystroke it did not
         /// own would be documenting a lie.
@@ -59,7 +60,7 @@ pub enum Item {
     /// only thing choosing it does is open.
     Submenu {
         label: SharedString,
-        icon: Option<&'static [u8]>,
+        icon: Option<Icon>,
         enabled: bool,
         items: Vec<Item>,
     },
@@ -88,10 +89,10 @@ impl Item {
     }
 
     /// No-ops on a separator, which has nothing to hang a glyph on.
-    pub fn with_icon(mut self, icon: &'static [u8]) -> Self {
+    pub fn with_icon(mut self, icon: impl Into<Icon>) -> Self {
         match &mut self {
             Item::Action { icon: slot, .. } | Item::Submenu { icon: slot, .. } => {
-                *slot = Some(icon)
+                *slot = Some(icon.into())
             }
             Item::Separator => {}
         }
@@ -461,7 +462,7 @@ impl<V: 'static> Tree<V> {
                         icon,
                         enabled,
                         ..
-                    } => (label.clone(), *icon, *enabled),
+                    } => (label.clone(), icon.clone(), *enabled),
                     Item::Separator => unreachable!("separators returned above"),
                 };
                 let description = match item {
@@ -578,7 +579,7 @@ fn row_id(id: &SharedString, path: &[usize]) -> SharedString {
 
 /// The leading column: the row's glyph, or the room one would have taken, so a
 /// menu of mixed rows keeps its labels on one edge.
-fn glyph_slot(theme: &Theme, icon: Option<&'static [u8]>, enabled: bool) -> gpui::Div {
+fn glyph_slot(theme: &Theme, icon: Option<Icon>, enabled: bool) -> gpui::Div {
     div()
         .flex_none()
         .size(px(GLYPH))

--- a/crates/ui/src/pagination.rs
+++ b/crates/ui/src/pagination.rs
@@ -21,6 +21,7 @@
 //! caller's — as with [`crate::table`]'s sort, this module reports and paints.
 
 use gpui::{SharedString, div, prelude::*, px};
+use icons::Icon;
 
 use theme::{TextStyle, Theme, Typeset};
 
@@ -144,7 +145,7 @@ pub fn ellipsis(theme: &Theme) -> gpui::Div {
 ///
 /// A disabled step stays in place rather than disappearing at the ends, so the
 /// row does not shuffle sideways on the first and last pages.
-pub fn step(theme: &Theme, icon: &'static [u8], enabled: bool) -> gpui::Div {
+pub fn step(theme: &Theme, icon: impl Into<Icon>, enabled: bool) -> gpui::Div {
     let step = div()
         .size(px(BUTTON))
         .rounded(px(7.0))

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -15,6 +15,7 @@ use crate::{icons, stack};
 use gpui::{
     Anchor, AnyElement, ElementId, IntoElement, Pixels, Point, SharedString, div, prelude::*, px,
 };
+use icons::Icon;
 use motion::{self as motion, AnimationExt as _, Fade, PULSE, Painter};
 use theme::{TextStyle, Theme, Typeset, hairline, ink};
 
@@ -1127,7 +1128,7 @@ fn key_hint_label(theme: &Theme, label: &'static str) -> gpui::Div {
 
 /// A footer legend: one icon key-cap + tiny verb (the add-space palette's
 /// footer voice, shared by the pickers).
-pub fn key_hint(theme: &Theme, icon_path: &'static [u8], label: &'static str) -> gpui::Div {
+pub fn key_hint(theme: &Theme, icon: impl Into<Icon>, label: &'static str) -> gpui::Div {
     div()
         .flex()
         .flex_row()
@@ -1135,7 +1136,7 @@ pub fn key_hint(theme: &Theme, icon_path: &'static [u8], label: &'static str) ->
         .gap(px(5.0))
         .child(
             key_cap(theme).child(
-                crate::icons::icon(icon_path)
+                crate::icons::icon(icon)
                     .size(px(12.5))
                     .text_color(theme.text_muted.opacity(0.7)),
             ),
@@ -1165,8 +1166,8 @@ pub fn key_hint_text(theme: &Theme, cap: &'static str, label: &'static str) -> g
 /// ("[ ↑ | ↓ ] Navigate") sharing one verb.
 pub fn key_hint_pair(
     theme: &Theme,
-    first: &'static [u8],
-    second: &'static [u8],
+    first: impl Into<Icon>,
+    second: impl Into<Icon>,
     label: &'static str,
 ) -> gpui::Div {
     div()

--- a/crates/ui/src/widgets/buttons.rs
+++ b/crates/ui/src/widgets/buttons.rs
@@ -9,6 +9,7 @@
 //! the looks that ship, while per-call overrides stay chain modifiers.
 
 use gpui::{Div, ElementId, SharedString, Stateful, div, prelude::*, px};
+use icons::Icon;
 use motion::{self, Fade};
 use theme::{ControlSize, Sizing, Theme, ThemeExt, ink};
 
@@ -91,13 +92,18 @@ pub trait Buttons: ThemeExt {
     ///
     /// An icon carries no accessible name — reach for
     /// [`crate::tooltip`] on the way past.
-    fn icon_button(&self, icon: &'static [u8], style: ButtonStyle, fade: Option<Fade>) -> Div {
+    fn icon_button(&self, icon: impl Into<Icon>, style: ButtonStyle, fade: Option<Fade>) -> Div {
         let theme = self.theme();
         let square = frame()
             .px(px(0.0))
             .w(px(Theme::BUTTON_HEIGHT))
             .justify_center();
-        let glyph = |tint| crate::icons::icon(icon).size(px(GLYPH)).text_color(tint);
+        let icon = icon.into();
+        let glyph = |tint| {
+            crate::icons::icon(icon.clone())
+                .size(px(GLYPH))
+                .text_color(tint)
+        };
         match style {
             ButtonStyle::Ghost => match fade {
                 Some(fade) => {

--- a/crates/ui/src/widgets/content.rs
+++ b/crates/ui/src/widgets/content.rs
@@ -4,6 +4,7 @@
 //! `theme.badge(..)`, `theme.avatar(..)`, `theme.empty_state(..)`.
 
 use gpui::{Div, SharedString, Svg, div, prelude::*, px};
+use icons::Icon;
 use theme::{TextStyle, Theme, ThemeExt, Typeset, ink};
 
 pub trait Content: ThemeExt {
@@ -123,7 +124,7 @@ pub trait Content: ThemeExt {
     /// The centered "nothing here yet" panel: icon, headline, one line of hint.
     fn empty_state(
         &self,
-        icon_path: &'static [u8],
+        icon: impl Into<Icon>,
         title: impl Into<SharedString>,
         hint: impl Into<SharedString>,
     ) -> Div {
@@ -137,7 +138,7 @@ pub trait Content: ThemeExt {
             .gap(px(6.0))
             .py(px(40.0))
             .child(
-                crate::icons::icon(icon_path)
+                crate::icons::icon(icon)
                     .size(px(24.0))
                     .text_color(theme.text_faint),
             )

--- a/crates/ui/src/widgets/icon.rs
+++ b/crates/ui/src/widgets/icon.rs
@@ -1,0 +1,34 @@
+//! Icons, as the environment paints them.
+//!
+//! A catalog trait, like every widget group: import it to unlock
+//! `theme.icon(..)` and `theme.icon_at(..)`.
+
+use gpui::{Svg, prelude::*, px};
+use icons::Icon;
+use theme::{TextStyle, ThemeExt};
+
+pub trait Icons: ThemeExt {
+    /// An icon at the ladder's body step, in the plain text tone.
+    ///
+    /// Both are defaults, not decisions: `Svg` is `Styled`, so a later
+    /// `.size(..)` or `.text_color(..)` wins, and a component's own metric
+    /// stays with the component. What this buys is the floor —
+    /// [`icons::icon`] paints *nothing* when no colour is set anywhere,
+    /// because gpui resolves an svg's tone from its own style and never
+    /// inherits one, so an icon with a forgotten `text_color` is invisible
+    /// rather than wrong.
+    fn icon(&self, icon: impl Into<Icon>) -> Svg {
+        self.icon_at(TextStyle::Body, icon)
+    }
+
+    /// The same, sized to a named rung — a caption's icon beside caption text.
+    /// The ladder is the one type reads, so the two move together when
+    /// [`theme::set_base_text_size`] does.
+    fn icon_at(&self, role: TextStyle, icon: impl Into<Icon>) -> Svg {
+        icons::icon(icon)
+            .size(px(role.painted()))
+            .text_color(self.theme().text)
+    }
+}
+
+impl Icons for theme::Theme {}

--- a/crates/ui/src/widgets/layout.rs
+++ b/crates/ui/src/widgets/layout.rs
@@ -6,6 +6,7 @@
 
 use crate::stack;
 use gpui::{Div, SharedString, Svg, div, prelude::*, px};
+use icons::Icon;
 use motion::{self, Fade};
 use theme::{TextStyle, Theme, ThemeExt, Typeset, card_selected_bg, ink};
 
@@ -89,7 +90,7 @@ pub trait Layout: ThemeExt {
     /// has claimed it.
     fn nav_row(
         &self,
-        icon: Option<&'static [u8]>,
+        icon: Option<Icon>,
         label: impl Into<SharedString>,
         selected: bool,
         fade: Fade,
@@ -117,11 +118,11 @@ pub trait Layout: ThemeExt {
             row = row.bg(motion::hover_blend(&fade, ink(0.0), theme.element_hover));
             row.interactivity().on_hover(motion::hover_listener(fade));
         }
-        row.when_some(icon, |row, path| {
+        row.when_some(icon, |row, icon| {
             // The tint is set on the svg itself: gpui reads an svg's colour off
             // that element's own style and paints nothing when it is unset.
             row.child(
-                crate::icons::icon(path)
+                crate::icons::icon(icon)
                     .size(px(16.0))
                     .flex_none()
                     .text_color(tint),

--- a/crates/ui/src/widgets/mod.rs
+++ b/crates/ui/src/widgets/mod.rs
@@ -1,6 +1,6 @@
 //! Widgets, grouped as catalog traits on `Theme` — import the group, reach
-//! the component: `use ui::widgets::{Content, Controls, Layout,
-//! Scaffolding, Status};` → `theme.group_box()`, `theme.tab(..)`.
+//! the component: `use ui::widgets::{Content, Controls, Icons,
+//! Layout, Scaffolding, Status};` → `theme.group_box()`, `theme.tab(..)`.
 //!
 //! What stays here is deliberately trait-shaped: state flags and pure math,
 //! neither of which reads the theme as a receiver.
@@ -10,6 +10,7 @@ use gpui::{div, prelude::*, px};
 mod buttons;
 mod content;
 mod controls;
+mod icon;
 mod layout;
 mod scaffolding;
 mod status;
@@ -17,6 +18,7 @@ mod status;
 pub use buttons::{ButtonStyle, Buttons};
 pub use content::Content;
 pub use controls::{Controls, SliderDrag, slider_fraction};
+pub use icon::Icons;
 pub use layout::{Layout, SPLIT_HANDLE_HIT, SplitDrag, SplitStyle};
 pub use scaffolding::{OPTION_CARD_HEIGHT, OPTION_CARD_RADIUS, Scaffolding};
 pub use status::Status;

--- a/crates/ui/src/widgets/scaffolding.rs
+++ b/crates/ui/src/widgets/scaffolding.rs
@@ -10,6 +10,7 @@
 
 use crate::stack;
 use gpui::{AnyElement, Div, SharedString, div, prelude::*, px};
+use icons::Icon;
 use theme::{TextStyle, Theme, ThemeExt, Typeset};
 
 /// Default height of an [`Scaffolding::option_card`] preview frame.
@@ -198,7 +199,7 @@ pub trait Scaffolding: ThemeExt {
 
     /// The leading symbol on a row: a bare glyph, sized to the text beside it,
     /// the way the macOS General pane carries one.
-    fn row_icon(&self, icon_path: &'static [u8]) -> Div {
+    fn row_icon(&self, icon: impl Into<Icon>) -> Div {
         let theme = self.theme();
         div()
             .flex_none()
@@ -207,7 +208,7 @@ pub trait Scaffolding: ThemeExt {
             .items_center()
             .justify_center()
             .child(
-                crate::icons::icon(icon_path)
+                crate::icons::icon(icon)
                     .size(px(ROW_ICON))
                     .text_color(theme.text_muted),
             )

--- a/crates/ui/src/widgets/status.rs
+++ b/crates/ui/src/widgets/status.rs
@@ -4,6 +4,7 @@
 //! `theme.step_row(..)`, `theme.step_output(..)`, `theme.error_strip(..)`.
 
 use gpui::{Div, SharedString, div, prelude::*, px};
+use icons::Icon;
 use theme::{TextStyle, Theme, ThemeExt, Typeset};
 
 use crate::{stack, widgets::Layout};
@@ -37,7 +38,7 @@ pub trait Status: ThemeExt {
     /// [`Theme::element_hover`].
     fn step_row(
         &self,
-        icon: &'static [u8],
+        icon: impl Into<Icon>,
         title: impl Into<SharedString>,
         detail: Option<SharedString>,
         meta: Option<SharedString>,

--- a/crates/ui/tests/menubar.rs
+++ b/crates/ui/tests/menubar.rs
@@ -66,7 +66,7 @@ fn the_builders_leave_each_others_fields_alone() {
     // Every builder rewrites the row it is given, so one that reached for the
     // wrong field would silently drop what an earlier call had put there.
     let full = Item::action("Save")
-        .with_icon("icon.svg")
+        .with_icon(ui::icons::glyph::Bell)
         .with_keystroke("⌘S")
         .with_description("Write the file to disk")
         .checked(true)

--- a/skills/bezel/SKILL.md
+++ b/skills/bezel/SKILL.md
@@ -81,8 +81,9 @@ gpui_platform::application().run(|cx: &mut App| {
    color argument, you want a chain modifier instead.
 2. **Stateless paint is a catalog trait on `Theme`.** Import the group, reach the
    method: `use ui::widgets::{ButtonStyle, Buttons};` → `theme.button(…)`. The
-   groups are `Buttons`, `Controls`, `Scaffolding`, `Layout`, `Content`, `Status`.
-   Stateful things are entities you hold (`TextField`, `Table`, `Orb`, `Palette`).
+   groups are `Buttons`, `Controls`, `Icons`, `Scaffolding`, `Layout`, `Content`
+   and `Status`. Stateful things are entities you hold (`TextField`, `Table`,
+   `Orb`, `Palette`).
 3. **Interaction is yours.** A widget returns a `gpui::Div`; you attach `.id()`
    and `.on_click()`. bezel never owns your handlers.
 4. **Write no numbers.** `ui::stack::row()` already carries the system gap.
@@ -109,6 +110,8 @@ gpui_platform::application().run(|cx: &mut App| {
 - **No menu, no `cmd-q`.** A gpui app gets no menu bar for free.
 - **Icon color.** gpui reads an SVG's color off the element's own style and
   paints *nothing* when unset — set it on the glyph, not on the parent.
+  `theme.icon(glyph::Search)` carries a tone and a ladder step already;
+  `icons::icon(..)` is the bare builder and needs both.
 - **Fade keys must be unique.** Two elements sharing one trade hover animations.
 
 ## When bezel is the thing that is wrong

--- a/www/docs/icons.md
+++ b/www/docs/icons.md
@@ -6,12 +6,33 @@ description: The Lucide set ported into typed SVG constants, one cargo feature p
 Name a glyph and paint it. There is no asset source to register:
 
 ```rust
-use ui::icons::{self, glyph};
+use ui::icons::{self, Icon, glyph};
+use ui::widgets::Icons;
 
+theme.icon(glyph::Search)                        // the ladder's body step, in the text tone
+theme.icon_at(TextStyle::Caption, glyph::Search) // another rung
 icons::icon(glyph::Search).size(px(16.0)).text_color(theme.text_muted)
 ```
 
-`icon` returns a gpui `Svg`, so it colors with `text_color` and sizes like any element.
+Both builders return a gpui `Svg`, so a `Styled` call after either one wins — what `theme.icon` supplies is a floor, not a decision, and a component that has its own metric sets it on top.
+
+That floor matters more than it looks. gpui resolves an svg's tone from that element's own style and never inherits one from an ancestor, so `icons::icon(..)` with no `text_color` anywhere paints **nothing** — no warning, no fallback, an empty box where the glyph should be. `theme.icon` is the same builder with the size and the tone already in it.
+
+## What a component takes
+
+`Icon` is the value, and it erases where the drawing came from:
+
+```rust
+theme.row_icon(glyph::Monitor)                 // a glyph compiled in
+theme.row_icon(Icon::asset("brand/mark.svg"))  // the app's own AssetSource
+theme.row_icon(Icon::file(picked))             // a file on disk
+```
+
+Every component that takes an icon takes `impl Into<Icon>`, so a constant passes as itself and neither the signature nor the component learns which kind it got. SwiftUI's `Image` erases its sources the same way, and for the same reason: the set cannot cover a product's own marks, and a library that only accepts its own set is one an app cannot use its logo with.
+
+`Icon::asset` is a key the app's registered `AssetSource` answers — bundled art, resolved the way gpui resolves any asset. `Icon::file` is a path on disk, for art that was not there at build time: one the user picked, one a fetch wrote down. gpui loads that off the paint thread and caches it, so the first frame or two paint nothing.
+
+An `Icon` carries no size and no colour. Those belong to the environment, which here is the component — a menu row's glyph is the row's metric, not the caller's.
 
 ## The set is Lucide's
 
@@ -39,4 +60,13 @@ bezel-icons = { version = "0.1", features = ["arrows", "navigation"] }
 
 ## Solid twins
 
-Lucide draws one weight. `icons::solid` fills the outline instead of reaching for a second drawing — filled *and* stroked, so the outer edge lands exactly where `icons::icon` puts it and a control swapping between them does not jump.
+Lucide draws one weight. `Icon::solid` fills the outline instead of reaching for a second drawing — filled *and* stroked, so the outer edge lands exactly where the outline puts it and a control swapping between them does not jump.
+
+```rust
+theme.icon(Icon::glyph(glyph::Star).solid())
+icons::solid(glyph::Star)                     // the same, for the common case
+```
+
+It is a property of the value rather than a second call, which is what lets a control hold one `Icon` and flip the variant — favourited or not — instead of branching between two functions. SwiftUI spells it `.symbolVariant(.fill)`.
+
+The filled document is a rewrite of the outline, made once per glyph and kept for the life of the process: the variant is a flag read at paint time, so without that it would be rebuilt on every frame a solid icon is on screen.


### PR DESCRIPTION
Release 0.1.10.

- `icons::Icon` is what a component takes — it erases whether the drawing is a glyph compiled in or `Icon::path(..)` the app's own `AssetSource` resolves. Every icon-taking signature moves to `impl Into<Icon>`, so constants still pass as themselves.
- `theme.icon(..)` / `theme.icon_at(role, ..)` paint from the type ladder and the palette. Defaults, not decisions — a `Styled` call after them wins. The floor matters: gpui reads an svg's tone off its own style and never inherits one, so an icon with nothing set paints nothing.
- Fixes menu rows, the one component the Lucide port left on `svg().path(..)` — the gutter opened empty. The gallery's File menu carries glyphs now.
- `bezel-icons` gets its own README; CI drops the three-OS `cargo build` nextest already does.

Breaking: `with_icon` and friends no longer take a path string.